### PR TITLE
fix: avoid div inside p in step list

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -430,7 +430,11 @@ export default function Page() {
             <ListItem key={key} disablePadding>
               <ListItemButton selected={state.current === key} onClick={() => go(key)}>
                 <ListItemIcon>{icon}</ListItemIcon>
-                <ListItemText primary={label} secondary={<StepBadge s={s} />} />
+                <ListItemText
+                  primary={label}
+                  secondary={<StepBadge s={s} />}
+                  secondaryTypographyProps={{ component: "div" }}
+                />
                 <ActiveIcon fontSize="small" />
               </ListItemButton>
             </ListItem>


### PR DESCRIPTION
## Summary
- prevent hydration mismatch by rendering step badge in a div inside list item

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dbae28450832ea6b537bfa9d497c1