### PR TITLE
Add environment selector and axios token service

### DIFF
--- a/src/components/steps/StepIntro.tsx
+++ b/src/components/steps/StepIntro.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Stack, TextField, Typography } from "@mui/material";
+import { Button, Stack, Typography, FormControl, InputLabel, Select, MenuItem } from "@mui/material";
 import PlayCircleIcon from "@mui/icons-material/PlayCircle";
 import { Action, WizardState } from "../../types";
 
@@ -14,24 +14,28 @@ export default function StepIntro({ state, dispatch, onGetStarted }: Props) {
     <Stack spacing={2}>
       <Typography variant="h5">API Testing Wizard</Typography>
       <Typography variant="body1">
-        Enter your client credentials to begin. Click <strong>Get Started</strong> to proceed. All data is kept in
-        memory only; reloading the page will reset the wizard.
+        Choose an environment and click <strong>Get Started</strong> to proceed. Client credentials will be entered in
+        the next step. All data is kept in memory only; reloading the page will reset the wizard.
       </Typography>
-      <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-        <TextField
-          label="Client ID"
-          value={state.clientId}
-          onChange={(e) => dispatch({ type: "SET_FIELD", key: "clientId", value: e.target.value })}
-          fullWidth
-        />
-        <TextField
-          label="Client Secret"
-          type="password"
-          value={state.clientSecret}
-          onChange={(e) => dispatch({ type: "SET_FIELD", key: "clientSecret", value: e.target.value })}
-          fullWidth
-        />
-      </Stack>
+      <FormControl fullWidth>
+        <InputLabel id="env-label">Environment</InputLabel>
+        <Select
+          labelId="env-label"
+          label="Environment"
+          value={state.environment}
+          onChange={(e) => {
+            const env = e.target.value as typeof state.environment;
+            dispatch({ type: "SET_FIELD", key: "environment", value: env });
+            if (typeof window !== "undefined") {
+              localStorage.setItem("environment", env);
+            }
+          }}
+        >
+          <MenuItem value="development">Development</MenuItem>
+          <MenuItem value="staging">Staging</MenuItem>
+          <MenuItem value="production">Production</MenuItem>
+        </Select>
+      </FormControl>
       <Stack direction="row" spacing={2}>
         <Button variant="contained" onClick={onGetStarted} endIcon={<PlayCircleIcon />}>Get Started</Button>
       </Stack>

--- a/src/components/steps/StepToken.tsx
+++ b/src/components/steps/StepToken.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Button, Chip, Stack, TextField, Typography } from "@mui/material";
 import LockOpenIcon from "@mui/icons-material/LockOpen";
 import JsonBox from "../JsonBox";
-import PollingPanel from "../PollingPanel";
 import { Action, StepKey, WizardState } from "../../types";
 
 interface Props {
@@ -10,10 +9,9 @@ interface Props {
   dispatch: React.Dispatch<Action>;
   runToken: () => void;
   go: (step: StepKey) => void;
-  onStopPolling: () => void;
 }
 
-export default function StepToken({ state, dispatch, runToken, go, onStopPolling }: Props) {
+export default function StepToken({ state, dispatch, runToken, go }: Props) {
   const s = state.steps.token;
   return (
     <Stack spacing={2}>
@@ -41,7 +39,6 @@ export default function StepToken({ state, dispatch, runToken, go, onStopPolling
       <JsonBox label="Request Payload" data={state.steps.token.request} />
       <JsonBox label="Response" data={state.steps.token.response} />
       <JsonBox label="Error" data={state.steps.token.error} />
-      <PollingPanel polling={state.steps.token.polling} onStop={onStopPolling} />
       <Stack direction="row" spacing={2}>
         <Button variant="outlined" onClick={() => go("upload")}>Next</Button>
       </Stack>

--- a/src/env/development.ts
+++ b/src/env/development.ts
@@ -1,0 +1,5 @@
+const development = {
+  baseUrl: "https://msblocks.seliselocal.com",
+};
+
+export default development;

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -1,0 +1,23 @@
+import development from "./development";
+import staging from "./staging";
+import production from "./production";
+
+export type Environment = "development" | "staging" | "production";
+
+export interface EnvConfig {
+  baseUrl: string;
+}
+
+const configs: Record<Environment, EnvConfig> = {
+  development,
+  staging,
+  production,
+};
+
+export function getEnv(): EnvConfig {
+  if (typeof window !== "undefined") {
+    const stored = (localStorage.getItem("environment") as Environment) || "development";
+    return configs[stored] || development;
+  }
+  return development;
+}

--- a/src/env/production.ts
+++ b/src/env/production.ts
@@ -1,0 +1,5 @@
+const production = {
+  baseUrl: "https://selise.app",
+};
+
+export default production;

--- a/src/env/staging.ts
+++ b/src/env/staging.ts
@@ -1,0 +1,5 @@
+const staging = {
+  baseUrl: "https://app.selisestage.com",
+};
+
+export default staging;

--- a/src/services/token.ts
+++ b/src/services/token.ts
@@ -1,0 +1,25 @@
+import axios from "axios";
+import { getEnv } from "../env";
+
+export function buildTokenRequest(clientId: string, clientSecret: string) {
+  const { baseUrl } = getEnv();
+  const url = `${baseUrl}/api/identity/v25/identity/token`;
+  const body = {
+    grant_type: "client_credentials",
+    client_id: clientId,
+    client_secret: clientSecret,
+  };
+  return { url, body, baseUrl };
+}
+
+export async function getToken(clientId: string, clientSecret: string) {
+  const { url, body, baseUrl } = buildTokenRequest(clientId, clientSecret);
+  const params = new URLSearchParams(body);
+  const res = await axios.post(url, params, {
+    headers: {
+      Origin: baseUrl,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+  });
+  return res.data;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface StepState {
 
 export interface WizardState {
   current: StepKey;
+  environment: "development" | "staging" | "production";
   clientId: string;
   clientSecret: string;
   token?: string;


### PR DESCRIPTION
## Summary
- Persist selected environment in local storage and use it in token service
- Drop token step polling and rely on axios service reading base URL from storage
- Save environment choice in intro step and load it on initialization
- Move base URLs into dedicated environment configs and expose a helper for services
- Refactor token service to consume env helper and keep page logic free of base URL handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dc13a17ac832eb1f49cbc98576d08