### PR TITLE
Add theme switcher navbar and persist credentials

### DIFF
--- a/src/components/JsonBox.tsx
+++ b/src/components/JsonBox.tsx
@@ -1,21 +1,42 @@
 import React from "react";
-import { Paper, Typography } from "@mui/material";
+import { IconButton, Paper, Stack, Typography } from "@mui/material";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import WrapTextIcon from "@mui/icons-material/WrapText";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { coldarkDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 
 export default function JsonBox({ label, data }: { label: string; data: any }) {
+  const [wrap, setWrap] = React.useState(true);
+  const json = data ? JSON.stringify(data, null, 2) : "";
+
+  const handleCopy = () => {
+    if (json && typeof navigator !== "undefined") {
+      navigator.clipboard.writeText(json);
+    }
+  };
+
   return (
     <Paper variant="elevation" elevation={0}>
-      <Typography variant="subtitle2" gutterBottom>
-        {label}
-      </Typography>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Typography variant="subtitle2" gutterBottom>
+          {label}
+        </Typography>
+        <Stack direction="row">
+          <IconButton size="small" onClick={handleCopy} aria-label="copy">
+            <ContentCopyIcon fontSize="inherit" />
+          </IconButton>
+          <IconButton size="small" onClick={() => setWrap((w) => !w)} aria-label="toggle wrap">
+            <WrapTextIcon fontSize="inherit" />
+          </IconButton>
+        </Stack>
+      </Stack>
       <SyntaxHighlighter
         language="json"
         style={coldarkDark}
         customStyle={{ margin: 0, fontSize: 16, wordBreak: "break-word", borderRadius: 16 }}
-        wrapLongLines
+        wrapLongLines={wrap}
       >
-        {data ? JSON.stringify(data, null, 2) : "—"}
+        {json || "—"}
       </SyntaxHighlighter>
     </Paper>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,26 @@
+"use client";
+import React from "react";
+import { AppBar, Toolbar, Box, IconButton } from "@mui/material";
+import LightModeIcon from "@mui/icons-material/LightMode";
+import DarkModeIcon from "@mui/icons-material/DarkMode";
+import Image from "next/image";
+
+interface NavbarProps {
+  mode: "light" | "dark";
+  toggleTheme: () => void;
+}
+
+export default function Navbar({ mode, toggleTheme }: NavbarProps) {
+  return (
+    <AppBar position="static" color="default" elevation={0}>
+      <Toolbar>
+        <Box sx={{ flexGrow: 1 }}>
+          <Image src="/file.svg" alt="Logo" width={32} height={32} />
+        </Box>
+        <IconButton onClick={toggleTheme}>
+          {mode === "light" ? <DarkModeIcon /> : <LightModeIcon />}
+        </IconButton>
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/src/components/steps/StepPrepare.tsx
+++ b/src/components/steps/StepPrepare.tsx
@@ -60,7 +60,7 @@ export default function StepPrepare({ state, dispatch, runPrepareOrPrepareSend, 
       </Stack>
       <JsonBox label="Request Payload" data={state.steps.prepare.request} />
       <JsonBox label="Response" data={state.steps.prepare.response} />
-      <JsonBox label="Error" data={state.steps.prepare.error} />
+      {state.steps.prepare.error && <JsonBox label="Error" data={state.steps.prepare.error} />}
       <PollingPanel polling={state.steps.prepare.polling} onStop={onStopPolling} />
       <Stack direction="row" spacing={2}>
         {state.actionChoice === "prepare" ? (

--- a/src/components/steps/StepSend.tsx
+++ b/src/components/steps/StepSend.tsx
@@ -30,7 +30,7 @@ export default function StepSend({ state, runSendOnly, go, onStopPolling }: Prop
       </Stack>
       <JsonBox label="Request Payload" data={state.steps.send.request} />
       <JsonBox label="Response" data={state.steps.send.response} />
-      <JsonBox label="Error" data={state.steps.send.error} />
+      {state.steps.send.error && <JsonBox label="Error" data={state.steps.send.error} />}
       <PollingPanel polling={state.steps.send.polling} onStop={onStopPolling} />
       <Stack direction="row" spacing={2}>
         <Button variant="outlined" onClick={() => go("done")}>Next</Button>

--- a/src/components/steps/StepToken.tsx
+++ b/src/components/steps/StepToken.tsx
@@ -21,14 +21,26 @@ export default function StepToken({ state, dispatch, runToken, go }: Props) {
         <TextField
           label="Client ID"
           value={state.clientId}
-          onChange={(e) => dispatch({ type: "SET_FIELD", key: "clientId", value: e.target.value })}
+          onChange={(e) => {
+            const v = e.target.value;
+            dispatch({ type: "SET_FIELD", key: "clientId", value: v });
+            if (typeof window !== "undefined") {
+              sessionStorage.setItem("clientId", v);
+            }
+          }}
           fullWidth
         />
         <TextField
           label="Client Secret"
           type="password"
           value={state.clientSecret}
-          onChange={(e) => dispatch({ type: "SET_FIELD", key: "clientSecret", value: e.target.value })}
+          onChange={(e) => {
+            const v = e.target.value;
+            dispatch({ type: "SET_FIELD", key: "clientSecret", value: v });
+            if (typeof window !== "undefined") {
+              sessionStorage.setItem("clientSecret", v);
+            }
+          }}
           fullWidth
         />
       </Stack>
@@ -38,7 +50,7 @@ export default function StepToken({ state, dispatch, runToken, go }: Props) {
       </Stack>
       <JsonBox label="Request Payload" data={state.steps.token.request} />
       <JsonBox label="Response" data={state.steps.token.response} />
-      <JsonBox label="Error" data={state.steps.token.error} />
+      {s.error && <JsonBox label="Error" data={s.error} />}
       <Stack direction="row" spacing={2}>
         <Button variant="outlined" onClick={() => go("upload")}>Next</Button>
       </Stack>

--- a/src/components/steps/StepUpload.tsx
+++ b/src/components/steps/StepUpload.tsx
@@ -39,7 +39,7 @@ export default function StepUpload({ state, dispatch, runUpload, go, onStopPolli
       </Stack>
       <JsonBox label="Request Payload" data={state.steps.upload.request} />
       <JsonBox label="Response" data={state.steps.upload.response} />
-      <JsonBox label="Error" data={state.steps.upload.error} />
+      {state.steps.upload.error && <JsonBox label="Error" data={state.steps.upload.error} />}
       <PollingPanel polling={state.steps.upload.polling} onStop={onStopPolling} />
       <Stack direction="row" spacing={2}>
         <Button variant="outlined" onClick={() => go("prepare")}>Next</Button>

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -1,0 +1,13 @@
+import { createTheme } from "@mui/material/styles";
+
+const darkTheme = createTheme({
+  palette: {
+    mode: "dark",
+    primary: { main: "#0ea5e9" },
+    secondary: { main: "#8b5cf6" },
+    success: { main: "#22c55e" },
+  },
+  shape: { borderRadius: 16 },
+});
+
+export default darkTheme;

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -1,0 +1,13 @@
+import { createTheme } from "@mui/material/styles";
+
+const lightTheme = createTheme({
+  palette: {
+    mode: "light",
+    primary: { main: "#0ea5e9" },
+    secondary: { main: "#8b5cf6" },
+    success: { main: "#22c55e" },
+  },
+  shape: { borderRadius: 16 },
+});
+
+export default lightTheme;


### PR DESCRIPTION
## Summary
- mark intro step complete on start and hide error panels when empty
- add JsonBox copy and wrap controls
- add top navbar with theme switcher (now a separate component) and remove doc link
- persist client credentials in session storage

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689e03c1be38832eb10e41b5285f661d