### PR TITLE
Persist theme and refactor layout

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "az-cdn.selise.biz",
+        pathname: "/selisecdn/cdn/signature/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,10 +12,15 @@ interface NavbarProps {
 
 export default function Navbar({ mode, toggleTheme }: NavbarProps) {
   return (
-    <AppBar position="static" color="default" elevation={0}>
+    <AppBar position="sticky" color="default" elevation={0}>
       <Toolbar>
         <Box sx={{ flexGrow: 1 }}>
-          <Image src="/file.svg" alt="Logo" width={32} height={32} />
+          <Image
+            src="https://az-cdn.selise.biz/selisecdn/cdn/signature/Selise%20signature%20new%20logo.svg"
+            alt="Logo"
+            width={120}
+            height={32}
+          />
         </Box>
         <IconButton onClick={toggleTheme}>
           {mode === "light" ? <DarkModeIcon /> : <LightModeIcon />}

--- a/src/components/Sidenav.tsx
+++ b/src/components/Sidenav.tsx
@@ -1,0 +1,105 @@
+"use client";
+import React from "react";
+import {
+  Paper,
+  Stack,
+  Typography,
+  Button,
+  Tooltip,
+  Switch,
+  FormControlLabel,
+  TextField,
+  Divider,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Chip,
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
+import PendingIcon from "@mui/icons-material/Pending";
+import PlayCircleIcon from "@mui/icons-material/PlayCircle";
+import { WizardState, Action, StepKey, StepState } from "../types";
+
+interface SidenavProps {
+  state: WizardState;
+  dispatch: React.Dispatch<Action>;
+  stepsOrder: { key: StepKey; label: string; icon: React.ReactNode }[];
+  runAll: () => Promise<void>;
+  go: (step: StepKey) => void;
+}
+
+function StepBadge({ s }: { s: StepState["status"] }) {
+  const color =
+    s === "success" ? "success" : s === "error" ? "error" : s === "running" ? "info" : "default";
+  const label = s[0].toUpperCase() + s.slice(1);
+  return <Chip size="small" color={color as any} label={label} />;
+}
+
+export default function Sidenav({ state, dispatch, stepsOrder, runAll, go }: SidenavProps) {
+  return (
+    <Paper elevation={0} sx={{ p: 2, height: "100%", overflow: "auto" }}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
+        <Typography variant="subtitle1">Steps</Typography>
+        <Tooltip title="Run all steps automatically with delays">
+          <span>
+            <Button
+              size="small"
+              variant="contained"
+              startIcon={<PlayCircleIcon />}
+              onClick={runAll}
+              disabled={state.autoRun}
+            >
+              Execute All
+            </Button>
+          </span>
+        </Tooltip>
+      </Stack>
+      <Stack direction="row" alignItems="center" sx={{ mb: 1 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={state.simulate}
+              onChange={(e) => dispatch({ type: "SET_FIELD", key: "simulate", value: e.target.checked })}
+            />
+          }
+          label="Simulate API"
+        />
+      </Stack>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
+        <TextField
+          label="Automation Delay (ms)"
+          type="number"
+          size="small"
+          value={state.autoDelayMs}
+          onChange={(e) => dispatch({ type: "SET_FIELD", key: "autoDelayMs", value: Number(e.target.value) })}
+          fullWidth
+        />
+      </Stack>
+      <Divider sx={{ mb: 2 }} />
+      <List>
+        {stepsOrder.map(({ key, label, icon }) => {
+          const s = state.steps[key].status;
+          const ActiveIcon =
+            s === "success" ? CheckCircleIcon : s === "running" ? PendingIcon : RadioButtonUncheckedIcon;
+          return (
+            <ListItem key={key} disablePadding>
+              <ListItemButton selected={state.current === key} onClick={() => go(key)}>
+                <ListItemIcon>{icon}</ListItemIcon>
+                <ListItemText
+                  primary={label}
+                  secondary={<StepBadge s={s} />}
+                  secondaryTypographyProps={{ component: "div" }}
+                />
+                <ActiveIcon fontSize="small" />
+              </ListItemButton>
+            </ListItem>
+          );
+        })}
+      </List>
+    </Paper>
+  );
+}
+


### PR DESCRIPTION
## Summary
- persist selected theme in local storage with system preference default
- refactor layout with sticky navbar and scrollable sidenav component
- allow external logo by configuring Next.js image domains

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e15ecfbec832e9faef4b0488dfe76