### PR TITLE
Improve theme scrollbars, status icons, and JSON box copy

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,12 @@
 * {
   scrollbar-width: thin;
+}
+
+[data-theme="light"] * {
+  scrollbar-color: #00000059 transparent;
+}
+
+[data-theme="dark"] * {
   scrollbar-color: #ffffff59 transparent;
 }
 
@@ -9,8 +16,15 @@
 }
 
 *::-webkit-scrollbar-thumb {
-  background-color: #ffffff59;
   border-radius: 8px;
+}
+
+[data-theme="light"] *::-webkit-scrollbar-thumb {
+  background-color: #00000059;
+}
+
+[data-theme="dark"] *::-webkit-scrollbar-thumb {
+  background-color: #ffffff59;
 }
 
 *::-webkit-scrollbar-track {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -180,10 +180,11 @@ export default function Page() {
   const [snack, setSnack] = useState<string | null>(null);
   const [mode, setMode] = useState<"light" | "dark">(() => {
     if (typeof window !== "undefined") {
-      return (
+      const stored =
         (localStorage.getItem("theme") as "light" | "dark") ||
-        (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
-      );
+        (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+      document.body.dataset.theme = stored;
+      return stored;
     }
     return "light";
   });
@@ -192,6 +193,7 @@ export default function Page() {
   useEffect(() => {
     if (typeof window !== "undefined") {
       localStorage.setItem("theme", mode);
+      document.body.dataset.theme = mode;
     }
   }, [mode]);
 

--- a/src/components/JsonBox.tsx
+++ b/src/components/JsonBox.tsx
@@ -10,13 +10,13 @@ export default function JsonBox({ label, data }: { label: string; data: any }) {
   const json = data ? JSON.stringify(data, null, 2) : "";
 
   const handleCopy = () => {
-    if (json && typeof navigator !== "undefined") {
-      navigator.clipboard.writeText(json);
+    if (json && typeof navigator !== "undefined" && navigator.clipboard) {
+      navigator.clipboard.writeText(json).catch(() => {});
     }
   };
 
   return (
-    <Paper variant="elevation" elevation={0} style={{ backgroundColor: "transparent"}}>
+    <Paper variant="elevation" elevation={0} style={{ backgroundColor: "transparent" }}>
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ py: 1 }}>
         <Typography variant="subtitle2" gutterBottom>
           {label}
@@ -33,7 +33,13 @@ export default function JsonBox({ label, data }: { label: string; data: any }) {
       <SyntaxHighlighter
         language="json"
         style={coldarkDark}
-        customStyle={{ margin: 0, fontSize: 16, wordBreak: "break-word", borderRadius: 16 }}
+        customStyle={{
+          margin: 0,
+          fontSize: 16,
+          borderRadius: 16,
+          wordBreak: "break-word",
+          whiteSpace: wrap ? "pre-wrap" : "pre",
+        }}
         wrapLongLines={wrap}
       >
         {json || "—"}

--- a/src/components/Sidenav.tsx
+++ b/src/components/Sidenav.tsx
@@ -15,13 +15,13 @@ import {
   ListItemButton,
   ListItemIcon,
   ListItemText,
-  Chip,
 } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import PendingIcon from "@mui/icons-material/Pending";
+import ErrorIcon from "@mui/icons-material/Error";
 import PlayCircleIcon from "@mui/icons-material/PlayCircle";
-import { WizardState, Action, StepKey, StepState } from "../types";
+import { WizardState, Action, StepKey } from "../types";
 
 interface SidenavProps {
   state: WizardState;
@@ -29,13 +29,6 @@ interface SidenavProps {
   stepsOrder: { key: StepKey; label: string; icon: React.ReactNode }[];
   runAll: () => Promise<void>;
   go: (step: StepKey) => void;
-}
-
-function StepBadge({ s }: { s: StepState["status"] }) {
-  const color =
-    s === "success" ? "success" : s === "error" ? "error" : s === "running" ? "info" : "default";
-  const label = s[0].toUpperCase() + s.slice(1);
-  return <Chip size="small" color={color as any} label={label} />;
 }
 
 export default function Sidenav({ state, dispatch, stepsOrder, runAll, go }: SidenavProps) {
@@ -83,17 +76,27 @@ export default function Sidenav({ state, dispatch, stepsOrder, runAll, go }: Sid
         {stepsOrder.map(({ key, label, icon }) => {
           const s = state.steps[key].status;
           const ActiveIcon =
-            s === "success" ? CheckCircleIcon : s === "running" ? PendingIcon : RadioButtonUncheckedIcon;
+            s === "success"
+              ? CheckCircleIcon
+              : s === "error"
+              ? ErrorIcon
+              : s === "running"
+              ? PendingIcon
+              : RadioButtonUncheckedIcon;
+          const color =
+            s === "success"
+              ? "success.main"
+              : s === "error"
+              ? "error.main"
+              : s === "running"
+              ? "info.main"
+              : "text.disabled";
           return (
             <ListItem key={key} disablePadding>
               <ListItemButton selected={state.current === key} onClick={() => go(key)}>
                 <ListItemIcon>{icon}</ListItemIcon>
-                <ListItemText
-                  primary={label}
-                  secondary={<StepBadge s={s} />}
-                  secondaryTypographyProps={{ component: "div" }}
-                />
-                <ActiveIcon fontSize="small" />
+                <ListItemText primary={label} />
+                <ActiveIcon fontSize="small" sx={{ color }} />
               </ListItemButton>
             </ListItem>
           );


### PR DESCRIPTION
## Summary
- ensure scrollbars contrast in light and dark modes
- indicate step results with green or red icons instead of chips
- fix JSON box wrapping and clipboard errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e20653024832e945f9848333e3336