### PR TITLE
fix: improve JsonBox functionality

### DIFF
--- a/src/components/JsonBox.tsx
+++ b/src/components/JsonBox.tsx
@@ -1,17 +1,38 @@
+"use client";
+
 import React from "react";
+import dynamic from "next/dynamic";
 import { IconButton, Paper, Stack, Typography } from "@mui/material";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import WrapTextIcon from "@mui/icons-material/WrapText";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { coldarkDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+
+const SyntaxHighlighter = dynamic(
+  () => import("react-syntax-highlighter").then((m) => m.Prism),
+  { ssr: false }
+);
 
 export default function JsonBox({ label, data }: { label: string; data: any }) {
   const [wrap, setWrap] = React.useState(true);
   const json = data ? JSON.stringify(data, null, 2) : "";
 
   const handleCopy = () => {
-    if (json && typeof navigator !== "undefined" && navigator.clipboard) {
+    if (!json) return;
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
       navigator.clipboard.writeText(json).catch(() => {});
+    } else if (typeof document !== "undefined") {
+      const textarea = document.createElement("textarea");
+      textarea.value = json;
+      textarea.style.position = "fixed";
+      textarea.style.top = "0";
+      textarea.style.left = "0";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      try {
+        document.execCommand("copy");
+      } catch {}
+      document.body.removeChild(textarea);
     }
   };
 
@@ -21,29 +42,25 @@ export default function JsonBox({ label, data }: { label: string; data: any }) {
         <Typography variant="subtitle2" gutterBottom>
           {label}
         </Typography>
-        <Stack direction="row">
-          <IconButton size="small" onClick={handleCopy} aria-label="copy">
-            <ContentCopyIcon fontSize="inherit" />
-          </IconButton>
-          <IconButton size="small" onClick={() => setWrap((w) => !w)} aria-label="toggle wrap">
-            <WrapTextIcon fontSize="inherit" />
-          </IconButton>
-        </Stack>
+      <Stack direction="row">
+        <IconButton size="small" onClick={handleCopy} aria-label="copy">
+          <ContentCopyIcon fontSize="inherit" />
+        </IconButton>
+        <IconButton size="small" onClick={() => setWrap((w) => !w)} aria-label="toggle wrap">
+          <WrapTextIcon fontSize="inherit" />
+        </IconButton>
       </Stack>
-      <SyntaxHighlighter
-        language="json"
-        style={coldarkDark}
-        customStyle={{
-          margin: 0,
-          fontSize: 16,
-          borderRadius: 16,
-          wordBreak: "break-word",
-          whiteSpace: wrap ? "pre-wrap" : "pre",
-        }}
-        wrapLongLines={wrap}
-      >
-        {json || "—"}
-      </SyntaxHighlighter>
-    </Paper>
-  );
+    </Stack>
+    <SyntaxHighlighter
+      language="json"
+      style={coldarkDark}
+      wrapLines={wrap}
+      wrapLongLines={wrap}
+      lineProps={{ style: { whiteSpace: wrap ? "pre-wrap" : "pre", wordBreak: wrap ? "break-word" : "normal" } }}
+      customStyle={{ margin: 0, fontSize: 16, borderRadius: 16 }}
+    >
+      {json || "—"}
+    </SyntaxHighlighter>
+  </Paper>
+);
 }


### PR DESCRIPTION
## Summary
- ensure JsonBox renders only on the client to fix hydration mismatch
- add fallback clipboard implementation for insecure contexts
- improve line wrapping in SyntaxHighlighter

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e253cacbc832e9ae4a1af374b8cdb