### PR TITLE
refactor: remove simulate API and fix hydration

### DIFF
--- a/src/components/Sidenav.tsx
+++ b/src/components/Sidenav.tsx
@@ -6,8 +6,6 @@ import {
   Typography,
   Button,
   Tooltip,
-  Switch,
-  FormControlLabel,
   TextField,
   Divider,
   List,
@@ -49,17 +47,6 @@ export default function Sidenav({ state, dispatch, stepsOrder, runAll, go }: Sid
             </Button>
           </span>
         </Tooltip>
-      </Stack>
-      <Stack direction="row" alignItems="center" sx={{ mb: 1 }}>
-        <FormControlLabel
-          control={
-            <Switch
-              checked={state.simulate}
-              onChange={(e) => dispatch({ type: "SET_FIELD", key: "simulate", value: e.target.checked })}
-            />
-          }
-          label="Simulate API"
-        />
       </Stack>
       <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
         <TextField

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,6 @@ export interface WizardState {
   actionChoice: "prepare" | "prepare_send";
   autoRun: boolean;
   autoDelayMs: number;
-  simulate: boolean;
   steps: Record<StepKey, StepState>;
 }
 


### PR DESCRIPTION
## Summary
- remove mock API and simulate option
- load persisted credentials and environment after mount to prevent hydration mismatch

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2fe7e7c44832ea8c18d072957c1df