### PR TITLE
Add pre-signed upload URL step

### DIFF
--- a/src/components/steps/StepDone.tsx
+++ b/src/components/steps/StepDone.tsx
@@ -10,7 +10,7 @@ export default function StepDone({ state }: Props) {
   const message = state.actionChoice === "prepare" ? "Contract is sent via email." : "Contract prepared and sent via email.";
   return (
     <Stack spacing={2}>
-      <Typography variant="h5">Step 6 — Complete</Typography>
+      <Typography variant="h5">Step 7 — Complete</Typography>
       <Alert severity="success">{message}</Alert>
       <Typography variant="body2">
         You can go back to any step on the left to review payloads and polling responses. Reloading the page will reset

--- a/src/components/steps/StepPrepare.tsx
+++ b/src/components/steps/StepPrepare.tsx
@@ -25,10 +25,10 @@ export default function StepPrepare({ state, dispatch, runPrepareOrPrepareSend, 
   const s = state.steps.prepare;
   return (
     <Stack spacing={2}>
-      <Typography variant="h6">Step 4 — Prepare / Prepare and Send</Typography>
+      <Typography variant="h6">Step 5 — Prepare / Prepare and Send</Typography>
       <Typography variant="body2">
         Choose an action and provide a list of recipient emails (comma-separated). If you choose <em>Prepare and Send</em>,
-        Step 5 will be skipped.
+        Step 6 will be skipped.
       </Typography>
       <FormControl fullWidth>
         <InputLabel id="action-label">Action</InputLabel>
@@ -53,7 +53,7 @@ export default function StepPrepare({ state, dispatch, runPrepareOrPrepareSend, 
         <Button
           variant="contained"
           onClick={runPrepareOrPrepareSend}
-          disabled={s.status === "running" || !state.steps.upload.response}
+          disabled={s.status === "running" || !state.fileId}
         >
           Run
         </Button>

--- a/src/components/steps/StepSend.tsx
+++ b/src/components/steps/StepSend.tsx
@@ -16,8 +16,8 @@ export default function StepSend({ state, runSendOnly, go, onStopPolling }: Prop
   const s = state.steps.send;
   return (
     <Stack spacing={2}>
-      <Typography variant="h6">Step 5 — Send Contract</Typography>
-      <Typography variant="body2">If you prepared the contract in Step 4, send it now.</Typography>
+      <Typography variant="h6">Step 6 — Send Contract</Typography>
+      <Typography variant="body2">If you prepared the contract in Step 5, send it now.</Typography>
       <Stack direction="row" spacing={2}>
         <Button
           variant="contained"

--- a/src/components/steps/StepToken.tsx
+++ b/src/components/steps/StepToken.tsx
@@ -52,7 +52,7 @@ export default function StepToken({ state, dispatch, runToken, go }: Props) {
       <JsonBox label="Response" data={state.steps.token.response} />
       {s.error && <JsonBox label="Error" data={s.error} />}
       <Stack direction="row" spacing={2}>
-        <Button variant="outlined" onClick={() => go("upload")}>Next</Button>
+        <Button variant="outlined" onClick={() => go("uploadUrl")}>Next</Button>
       </Stack>
     </Stack>
   );

--- a/src/components/steps/StepUpload.tsx
+++ b/src/components/steps/StepUpload.tsx
@@ -17,7 +17,7 @@ export default function StepUpload({ state, dispatch, runUpload, go, onStopPolli
   const s = state.steps.upload;
   return (
     <Stack spacing={2}>
-      <Typography variant="h6">Step 3 — Upload File</Typography>
+      <Typography variant="h6">Step 4 — Upload File</Typography>
       <Typography variant="body2">Select a single PDF and upload it.</Typography>
       <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
         <Button component="label" variant="contained" startIcon={<CloudUploadIcon />}>Choose PDF
@@ -35,7 +35,13 @@ export default function StepUpload({ state, dispatch, runUpload, go, onStopPolli
         <TextField label="Selected file" value={state.fileName || "(none)"} InputProps={{ readOnly: true }} fullWidth />
       </Stack>
       <Stack direction="row" spacing={2}>
-        <Button variant="contained" onClick={runUpload} disabled={s.status === "running" || !state.file}>Upload</Button>
+        <Button
+          variant="contained"
+          onClick={runUpload}
+          disabled={s.status === "running" || !state.file || !state.uploadUrl}
+        >
+          Upload
+        </Button>
       </Stack>
       <JsonBox label="Request" data={state.steps.upload.request} />
       <JsonBox label="Response" data={state.steps.upload.response} />

--- a/src/components/steps/StepUploadUrl.tsx
+++ b/src/components/steps/StepUploadUrl.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Button, Stack, TextField, Typography } from "@mui/material";
+import LinkIcon from "@mui/icons-material/Link";
+import JsonBox from "../JsonBox";
+import { Action, StepKey, WizardState } from "../../types";
+
+interface Props {
+  state: WizardState;
+  dispatch: React.Dispatch<Action>;
+  runGetUploadUrl: () => void;
+  go: (step: StepKey) => void;
+}
+
+export default function StepUploadUrl({ state, dispatch, runGetUploadUrl, go }: Props) {
+  const s = state.steps.uploadUrl;
+  return (
+    <Stack spacing={2}>
+      <Typography variant="h6">Step 3 — Get Upload Url</Typography>
+      <Typography variant="body2">Request a pre-signed URL for file upload.</Typography>
+      <TextField
+        label="File Name"
+        value={state.fileName || ""}
+        onChange={(e) => dispatch({ type: "SET_FIELD", key: "fileName", value: e.target.value })}
+        fullWidth
+      />
+      <Stack direction="row" spacing={2}>
+        <Button
+          variant="contained"
+          onClick={runGetUploadUrl}
+          disabled={s.status === "running" || !state.fileName}
+          startIcon={<LinkIcon />}
+        >
+          Get Upload Url
+        </Button>
+      </Stack>
+      <JsonBox label="Request" data={state.steps.uploadUrl.request} />
+      <JsonBox label="Response" data={state.steps.uploadUrl.response} />
+      {s.error && <JsonBox label="Error" data={s.error} />}
+      <Stack direction="row" spacing={2}>
+        <Button variant="outlined" onClick={() => go("upload")}>Next</Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/services/contract.ts
+++ b/src/services/contract.ts
@@ -1,0 +1,29 @@
+import axios from "axios";
+
+export async function prepareContract(url: string, body: any, token?: string) {
+  const res = await axios.post(url, body, {
+    headers: token ? { Authorization: `bearer ${token}` } : undefined,
+  });
+  return res.data;
+}
+
+export async function prepareAndSendContract(url: string, body: any, token?: string) {
+  const res = await axios.post(url, body, {
+    headers: token ? { Authorization: `bearer ${token}` } : undefined,
+  });
+  return res.data;
+}
+
+export async function sendContract(url: string, body: any, token?: string) {
+  const res = await axios.post(url, body, {
+    headers: token ? { Authorization: `bearer ${token}` } : undefined,
+  });
+  return res.data;
+}
+
+export async function pollProcess(url: string, body: any, token?: string) {
+  const res = await axios.post(url, body, {
+    headers: token ? { Authorization: `bearer ${token}` } : undefined,
+  });
+  return res.data;
+}

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,0 +1,29 @@
+import axios from "axios";
+
+export function buildGetUploadUrlBody(itemId: string, name: string) {
+  return {
+    ItemId: itemId,
+    MetaData: "{}",
+    Name: name,
+    ParentDirectoryId: "",
+    Tags: '["File"]',
+  };
+}
+
+export async function getUploadUrl(url: string, itemId: string, name: string, token?: string) {
+  const body = buildGetUploadUrlBody(itemId, name);
+  const res = await axios.post(url, body, {
+    headers: token ? { Authorization: `bearer ${token}` } : undefined,
+  });
+  return res.data;
+}
+
+export async function uploadFile(url: string, file: Blob | ArrayBuffer) {
+  const res = await axios.put(url, file);
+  return { status: res.status };
+}
+
+export async function pollUploadStatus(url: string, fileId: string) {
+  const res = await axios.post(url, { fileId });
+  return res.data;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type StepKey =
   | "intro"
   | "token"
+  | "uploadUrl"
   | "upload"
   | "prepare"
   | "send"
@@ -26,6 +27,8 @@ export interface WizardState {
   token?: string;
   file?: File | null;
   fileName?: string;
+  uploadUrl?: string;
+  fileId?: string;
   processId?: string;
   emails: string;
   actionChoice: "prepare" | "prepare_send";


### PR DESCRIPTION
## Summary
- remove request helper and switch to axios-based services
- add contract service for prepare, send, and poll operations
- use the service methods from the main page, eliminating direct fetch calls

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a312ca0e8c832e9f9918647ed062e9