### PR TITLE
Move file picker to upload URL step

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -367,7 +367,6 @@ export default function Page() {
       {state.current === "upload" && (
         <StepUpload
           state={state}
-          dispatch={dispatch}
           runUpload={runUpload}
           go={go}
           onStopPolling={() => {

--- a/src/components/steps/StepUpload.tsx
+++ b/src/components/steps/StepUpload.tsx
@@ -1,39 +1,23 @@
 import React from "react";
 import { Button, Stack, TextField, Typography } from "@mui/material";
-import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import JsonBox from "../JsonBox";
 import PollingPanel from "../PollingPanel";
-import { Action, StepKey, WizardState } from "../../types";
+import { StepKey, WizardState } from "../../types";
 
 interface Props {
   state: WizardState;
-  dispatch: React.Dispatch<Action>;
   runUpload: () => void;
   go: (step: StepKey) => void;
   onStopPolling: () => void;
 }
 
-export default function StepUpload({ state, dispatch, runUpload, go, onStopPolling }: Props) {
+export default function StepUpload({ state, runUpload, go, onStopPolling }: Props) {
   const s = state.steps.upload;
   return (
     <Stack spacing={2}>
       <Typography variant="h6">Step 4 — Upload File</Typography>
-      <Typography variant="body2">Select a single PDF and upload it.</Typography>
-      <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-        <Button component="label" variant="contained" startIcon={<CloudUploadIcon />}>Choose PDF
-          <input
-            type="file"
-            accept="application/pdf"
-            hidden
-            onChange={(e) => {
-              const f = e.target.files?.[0] || null;
-              dispatch({ type: "SET_FIELD", key: "file", value: f });
-              dispatch({ type: "SET_FIELD", key: "fileName", value: f?.name || undefined });
-            }}
-          />
-        </Button>
-        <TextField label="Selected file" value={state.fileName || "(none)"} InputProps={{ readOnly: true }} fullWidth />
-      </Stack>
+      <Typography variant="body2">Upload the selected PDF using the pre-signed URL.</Typography>
+      <TextField label="Selected file" value={state.fileName || "(none)"} InputProps={{ readOnly: true }} fullWidth />
       <Stack direction="row" spacing={2}>
         <Button
           variant="contained"

--- a/src/components/steps/StepUploadUrl.tsx
+++ b/src/components/steps/StepUploadUrl.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Button, Stack, TextField, Typography } from "@mui/material";
 import LinkIcon from "@mui/icons-material/Link";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import JsonBox from "../JsonBox";
 import { Action, StepKey, WizardState } from "../../types";
 
@@ -16,18 +17,27 @@ export default function StepUploadUrl({ state, dispatch, runGetUploadUrl, go }: 
   return (
     <Stack spacing={2}>
       <Typography variant="h6">Step 3 — Get Upload Url</Typography>
-      <Typography variant="body2">Request a pre-signed URL for file upload.</Typography>
-      <TextField
-        label="File Name"
-        value={state.fileName || ""}
-        onChange={(e) => dispatch({ type: "SET_FIELD", key: "fileName", value: e.target.value })}
-        fullWidth
-      />
+      <Typography variant="body2">Choose a PDF and request a pre-signed URL for upload.</Typography>
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+        <Button component="label" variant="contained" startIcon={<CloudUploadIcon />}>Choose PDF
+          <input
+            type="file"
+            accept="application/pdf"
+            hidden
+            onChange={(e) => {
+              const f = e.target.files?.[0] || null;
+              dispatch({ type: "SET_FIELD", key: "file", value: f });
+              dispatch({ type: "SET_FIELD", key: "fileName", value: f?.name || undefined });
+            }}
+          />
+        </Button>
+        <TextField label="Selected file" value={state.fileName || "(none)"} InputProps={{ readOnly: true }} fullWidth />
+      </Stack>
       <Stack direction="row" spacing={2}>
         <Button
           variant="contained"
           onClick={runGetUploadUrl}
-          disabled={s.status === "running" || !state.fileName}
+          disabled={s.status === "running" || !state.file}
           startIcon={<LinkIcon />}
         >
           Get Upload Url


### PR DESCRIPTION
## Summary
- Move PDF chooser into the "Get Upload Url" step and auto-fill file name from the chosen file
- Simplify "Upload File" step to only upload the previously selected file
- Remove redundant dispatch prop from the upload step

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4142e43dc832eb0df5850b5c9e56d