### PR TITLE
refactor: load service URLs from env

### DIFF
--- a/src/env/development.ts
+++ b/src/env/development.ts
@@ -1,6 +1,12 @@
 const development = {
   baseUrl: "https://msblocks.seliselocal.com",
   tokenApi: "api/identity/v20/identity/token",
+  getUploadUrlApi: "api/storageservice/v23/StorageService/StorageQuery/GetPreSignedUrlForUpload",
+  pollUploadStatusApi: "api/storageservice/v23/StorageService/StorageQuery/PollUploadStatus",
+  prepareContractApi: "api/signature/v1/Contract/Prepare",
+  prepareAndSendContractApi: "api/signature/v1/Contract/PrepareAndSend",
+  sendContractApi: "api/signature/v1/Contract/Send",
+  pollProcessApi: "api/signature/v1/Contract/PollProcess",
 };
 
 export default development;

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -7,6 +7,12 @@ export type Environment = "development" | "staging" | "production";
 export interface EnvConfig {
   baseUrl: string;
   tokenApi: string;
+  getUploadUrlApi: string;
+  pollUploadStatusApi: string;
+  prepareContractApi: string;
+  prepareAndSendContractApi: string;
+  sendContractApi: string;
+  pollProcessApi: string;
 }
 
 const configs: Record<Environment, EnvConfig> = {

--- a/src/env/production.ts
+++ b/src/env/production.ts
@@ -1,6 +1,12 @@
 const production = {
   baseUrl: "https://selise.app",
   tokenApi: "api/identity/v100/identity/token",
+  getUploadUrlApi: "api/storageservice/v23/StorageService/StorageQuery/GetPreSignedUrlForUpload",
+  pollUploadStatusApi: "api/storageservice/v23/StorageService/StorageQuery/PollUploadStatus",
+  prepareContractApi: "api/signature/v1/Contract/Prepare",
+  prepareAndSendContractApi: "api/signature/v1/Contract/PrepareAndSend",
+  sendContractApi: "api/signature/v1/Contract/Send",
+  pollProcessApi: "api/signature/v1/Contract/PollProcess",
 };
 
 export default production;

--- a/src/env/staging.ts
+++ b/src/env/staging.ts
@@ -1,6 +1,12 @@
 const staging = {
   baseUrl: "https://app.selisestage.com",
   tokenApi: "api/identity/v25/identity/token",
+  getUploadUrlApi: "api/storageservice/v23/StorageService/StorageQuery/GetPreSignedUrlForUpload",
+  pollUploadStatusApi: "api/storageservice/v23/StorageService/StorageQuery/PollUploadStatus",
+  prepareContractApi: "api/signature/v1/Contract/Prepare",
+  prepareAndSendContractApi: "api/signature/v1/Contract/PrepareAndSend",
+  sendContractApi: "api/signature/v1/Contract/Send",
+  pollProcessApi: "api/signature/v1/Contract/PollProcess",
 };
 
 export default staging;

--- a/src/services/contract.ts
+++ b/src/services/contract.ts
@@ -1,27 +1,51 @@
 import axios from "axios";
+import { getEnv } from "../env";
 
-export async function prepareContract(url: string, body: any, token?: string) {
-  const res = await axios.post(url, body, {
+export function buildPrepareContractRequest(body: any) {
+  const { baseUrl, prepareContractApi } = getEnv();
+  const url = `${baseUrl}/${prepareContractApi}`;
+  return { url, body };
+}
+
+export async function prepareContract(body: any, token?: string) {
+  const { url, body: payload } = buildPrepareContractRequest(body);
+  const res = await axios.post(url, payload, {
     headers: token ? { Authorization: `bearer ${token}` } : undefined,
   });
   return res.data;
 }
 
-export async function prepareAndSendContract(url: string, body: any, token?: string) {
-  const res = await axios.post(url, body, {
+export function buildPrepareAndSendContractRequest(body: any) {
+  const { baseUrl, prepareAndSendContractApi } = getEnv();
+  const url = `${baseUrl}/${prepareAndSendContractApi}`;
+  return { url, body };
+}
+
+export async function prepareAndSendContract(body: any, token?: string) {
+  const { url, body: payload } = buildPrepareAndSendContractRequest(body);
+  const res = await axios.post(url, payload, {
     headers: token ? { Authorization: `bearer ${token}` } : undefined,
   });
   return res.data;
 }
 
-export async function sendContract(url: string, body: any, token?: string) {
-  const res = await axios.post(url, body, {
+export function buildSendContractRequest(body: any) {
+  const { baseUrl, sendContractApi } = getEnv();
+  const url = `${baseUrl}/${sendContractApi}`;
+  return { url, body };
+}
+
+export async function sendContract(body: any, token?: string) {
+  const { url, body: payload } = buildSendContractRequest(body);
+  const res = await axios.post(url, payload, {
     headers: token ? { Authorization: `bearer ${token}` } : undefined,
   });
   return res.data;
 }
 
-export async function pollProcess(url: string, body: any, token?: string) {
+export async function pollProcess(body: any, token?: string) {
+  const { baseUrl, pollProcessApi } = getEnv();
+  const url = `${baseUrl}/${pollProcessApi}`;
   const res = await axios.post(url, body, {
     headers: token ? { Authorization: `bearer ${token}` } : undefined,
   });

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
+import { getEnv } from "../env";
 
-export function buildGetUploadUrlBody(itemId: string, name: string) {
+function buildGetUploadUrlBody(itemId: string, name: string) {
   return {
     ItemId: itemId,
     MetaData: "{}",
@@ -10,8 +11,15 @@ export function buildGetUploadUrlBody(itemId: string, name: string) {
   };
 }
 
-export async function getUploadUrl(url: string, itemId: string, name: string, token?: string) {
+export function buildGetUploadUrlRequest(itemId: string, name: string) {
+  const { baseUrl, getUploadUrlApi } = getEnv();
+  const url = `${baseUrl}/${getUploadUrlApi}`;
   const body = buildGetUploadUrlBody(itemId, name);
+  return { url, body };
+}
+
+export async function getUploadUrl(itemId: string, name: string, token?: string) {
+  const { url, body } = buildGetUploadUrlRequest(itemId, name);
   const res = await axios.post(url, body, {
     headers: token ? { Authorization: `bearer ${token}` } : undefined,
   });
@@ -23,7 +31,9 @@ export async function uploadFile(url: string, file: Blob | ArrayBuffer) {
   return { status: res.status };
 }
 
-export async function pollUploadStatus(url: string, fileId: string) {
+export async function pollUploadStatus(fileId: string) {
+  const { baseUrl, pollUploadStatusApi } = getEnv();
+  const url = `${baseUrl}/${pollUploadStatusApi}`;
   const res = await axios.post(url, { fileId });
   return res.data;
 }


### PR DESCRIPTION
## Summary
- add request builders in storage and contract services so each service resolves its own API URLs
- update page logic to rely on these helpers instead of reading env vars directly

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a41fb27f48832ea48168049899717a