### PR TITLE
Fix upload button state and remove upload polling

### DIFF
--- a/src/components/steps/StepUpload.tsx
+++ b/src/components/steps/StepUpload.tsx
@@ -1,18 +1,20 @@
 import React from "react";
 import { Button, Stack, TextField, Typography } from "@mui/material";
 import JsonBox from "../JsonBox";
-import PollingPanel from "../PollingPanel";
 import { StepKey, WizardState } from "../../types";
 
 interface Props {
   state: WizardState;
   runUpload: () => void;
   go: (step: StepKey) => void;
-  onStopPolling: () => void;
 }
 
-export default function StepUpload({ state, runUpload, go, onStopPolling }: Props) {
+export default function StepUpload({ state, runUpload, go }: Props) {
   const s = state.steps.upload;
+  const uploadUrl =
+    state.uploadUrl ||
+    (state.steps.uploadUrl.response as any)?.url ||
+    (state.steps.uploadUrl.response as any)?.uploadUrl;
   return (
     <Stack spacing={2}>
       <Typography variant="h6">Step 4 — Upload File</Typography>
@@ -22,7 +24,7 @@ export default function StepUpload({ state, runUpload, go, onStopPolling }: Prop
         <Button
           variant="contained"
           onClick={runUpload}
-          disabled={s.status === "running" || !state.file || !state.uploadUrl}
+          disabled={s.status === "running" || !state.file || !uploadUrl}
         >
           Upload
         </Button>
@@ -30,7 +32,6 @@ export default function StepUpload({ state, runUpload, go, onStopPolling }: Prop
       <JsonBox label="Request" data={state.steps.upload.request} />
       <JsonBox label="Response" data={state.steps.upload.response} />
       {state.steps.upload.error && <JsonBox label="Error" data={state.steps.upload.error} />}
-      <PollingPanel polling={state.steps.upload.polling} onStop={onStopPolling} />
       <Stack direction="row" spacing={2}>
         <Button variant="outlined" onClick={() => go("prepare")}>Next</Button>
       </Stack>


### PR DESCRIPTION
## Summary
- ensure the Upload button enables once a presigned URL is available
- remove polling UI and logic from the upload step

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4280ffd80832ebcc4142014183e7a