### PR TITLE
feat: consolidate polling and improve prepare request

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import SettingsEthernetIcon from "@mui/icons-material/SettingsEthernet";
 import LinkIcon from "@mui/icons-material/Link";
 import { getToken, buildTokenRequest } from "../services/token";
 import {
-  pollProcess,
+  getEvents,
   prepareAndSendContract,
   prepareContract,
   sendContract,
@@ -224,11 +224,11 @@ export default function Page() {
       dispatch({ type: "SET_STEP", step: "prepare", patch: { status: "running", error: undefined } });
       const emails = state.emails.split(",").map((e) => e.trim()).filter(Boolean);
       const body = { emails, fileId: state.fileId!, title: state.title, signatureClass: state.signatureClass };
-      const { url } =
+      const { url, body: payload } =
         state.actionChoice === "prepare_send"
           ? buildPrepareAndSendContractRequest(body)
           : buildPrepareContractRequest(body);
-      dispatch({ type: "SET_STEP", step: "prepare", patch: { request: { url, body } } });
+      dispatch({ type: "SET_STEP", step: "prepare", patch: { request: { url, body: payload } } });
       const data =
         state.actionChoice === "prepare_send"
           ? await prepareAndSendContract(body, state.token)
@@ -253,7 +253,7 @@ export default function Page() {
             patch: { polling: { isActive: true, logs: [ ...(state.steps.prepare.polling?.logs || []), payload ], last: payload } },
           });
         },
-        () => pollProcess({ processId }, state.token),
+        () => getEvents({ processId }, state.token),
         (p) => p.status === "completed"
       );
 
@@ -281,7 +281,7 @@ export default function Page() {
         (payload) => {
           dispatch({ type: "SET_STEP", step: "send", patch: { polling: { isActive: true, logs: [ ...(state.steps.send.polling?.logs || []), payload ], last: payload } } });
         },
-        () => pollProcess({ processId }, state.token),
+        () => getEvents({ processId }, state.token),
         (p) => p.status === "completed"
       );
 

--- a/src/components/steps/StepPrepare.tsx
+++ b/src/components/steps/StepPrepare.tsx
@@ -48,13 +48,18 @@ export default function StepPrepare({ state, dispatch, runPrepareOrPrepareSend, 
         onChange={(e) => dispatch({ type: "SET_FIELD", key: "title", value: e.target.value })}
         fullWidth
       />
-      <TextField
-        label="Signature Class"
-        type="number"
-        value={state.signatureClass}
-        onChange={(e) => dispatch({ type: "SET_FIELD", key: "signatureClass", value: Number(e.target.value) })}
-        fullWidth
-      />
+      <FormControl fullWidth>
+        <InputLabel id="signature-class-label">Signature Class</InputLabel>
+        <Select
+          labelId="signature-class-label"
+          label="Signature Class"
+          value={state.signatureClass}
+          onChange={(e) => dispatch({ type: "SET_FIELD", key: "signatureClass", value: Number(e.target.value) })}
+        >
+          <MenuItem value={0}>Simple</MenuItem>
+          <MenuItem value={9}>Advanced</MenuItem>
+        </Select>
+      </FormControl>
       <TextField
         label="Emails (comma-separated)"
         placeholder="a@x.com, b@y.com"

--- a/src/env/development.ts
+++ b/src/env/development.ts
@@ -6,7 +6,7 @@ const development = {
   prepareContractApi: "api/selisign/v42/SeliSign//ExternalApp/PrepareContract",
   prepareAndSendContractApi: "api/selisign/v42/SeliSign//ExternalApp/PrepareAndSendContract",
   sendContractApi: "api/selisign/v42/SeliSign//ExternalApp/RolloutContract",
-  pollProcessApi: "api/signature/v1/Contract/PollProcess",
+  getEventsApi: "api/selisign/v42/SeliSign//ExternalApp/GetEvents",
 };
 
 export default development;

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -12,7 +12,7 @@ export interface EnvConfig {
   prepareContractApi: string;
   prepareAndSendContractApi: string;
   sendContractApi: string;
-  pollProcessApi: string;
+  getEventsApi: string;
 }
 
 const configs: Record<Environment, EnvConfig> = {

--- a/src/env/production.ts
+++ b/src/env/production.ts
@@ -6,7 +6,7 @@ const production = {
   prepareContractApi: "api/selisign/s1/SeliSign//ExternalApp/PrepareContract",
   prepareAndSendContractApi: "api/selisign/s1/SeliSign//ExternalApp/PrepareAndSendContract",
   sendContractApi: "api/selisign/s1/SeliSign//ExternalApp/RolloutContract",
-  pollProcessApi: "api/signature/v1/Contract/PollProcess",
+  getEventsApi: "api/selisign/s1/SeliSign//ExternalApp/GetEvents",
 };
 
 export default production;

--- a/src/env/staging.ts
+++ b/src/env/staging.ts
@@ -6,7 +6,7 @@ const staging = {
   prepareContractApi: "api/selisign/v65/SeliSign//ExternalApp/PrepareContract",
   prepareAndSendContractApi: "api/selisign/v65/SeliSign//ExternalApp/PrepareAndSendContract",
   sendContractApi: "api/selisign/v65/SeliSign//ExternalApp/RolloutContract",
-  pollProcessApi: "api/signature/v1/Contract/PollProcess",
+  getEventsApi: "api/selisign/v65/SeliSign//ExternalApp/GetEvents",
 };
 
 export default staging;

--- a/src/services/contract.ts
+++ b/src/services/contract.ts
@@ -77,9 +77,9 @@ export async function sendContract(body: any, token?: string) {
   return res.data;
 }
 
-export async function pollProcess(body: any, token?: string) {
-  const { baseUrl, pollProcessApi } = getEnv();
-  const url = `${baseUrl}/${pollProcessApi}`;
+export async function getEvents(body: any, token?: string) {
+  const { baseUrl, getEventsApi } = getEnv();
+  const url = `${baseUrl}/${getEventsApi}`;
   const res = await axios.post(url, body, {
     headers: token ? { Authorization: `bearer ${token}` } : undefined,
   });


### PR DESCRIPTION
## Summary
- show exact payload in prepare request preview
- use select for signature class with Simple and Advanced options
- unify polling through `/ExternalApp/GetEvents`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a44392c9a8832e8ed3e5e8c5290bb8