### PR TITLE
Include DocumentId in GetEvents polling payload

### DIFF
--- a/src/services/contract.ts
+++ b/src/services/contract.ts
@@ -77,10 +77,19 @@ export async function sendContract(body: any, token?: string) {
   return res.data;
 }
 
-export async function getEvents(body: any, token?: string) {
+interface GetEventsBody {
+  processId: string;
+  DocumentId?: string;
+}
+
+export async function getEvents({ processId, DocumentId }: GetEventsBody, token?: string) {
   const { baseUrl, getEventsApi } = getEnv();
   const url = `${baseUrl}/${getEventsApi}`;
-  const res = await axios.post(url, body, {
+  const payload: any = { processId };
+  if (DocumentId) {
+    payload.DocumentId = DocumentId;
+  }
+  const res = await axios.post(url, payload, {
     headers: token ? { Authorization: `bearer ${token}` } : undefined,
   });
   return res.data;


### PR DESCRIPTION
## Summary
- send DocumentId when polling GetEvents to accurately retrieve document events
- ensure prepare step waits for `preparation_success` event before completing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a448b46408832ea650ea68ed33d6e4