### PR TITLE
Adjust polling interval and stop condition

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -99,7 +99,7 @@ function usePoller() {
       onTick: (payload: any) => void,
       fetcher: () => Promise<any>,
       isDone: (payload: any) => boolean,
-      intervalMs = 1500
+      intervalMs = 5000
     ) => {
       // Kick an immediate tick, then interval
       const first = await fetcher();
@@ -256,7 +256,10 @@ export default function Page() {
         () => getEvents({ processId, DocumentId: documentId }, state.token),
         (p) => {
           const events = p.events || p.Events;
-          return Array.isArray(events) && events.some((e: any) => e.Status === "preparation_success" && e.Success);
+          return (
+            Array.isArray(events) &&
+            events.some((e: any) => e.Status === "preparation_success" && typeof e.Success === "boolean")
+          );
         }
       );
 


### PR DESCRIPTION
## Summary
- poll events every 5 seconds by default
- stop prepare contract polling once a `preparation_success` event appears, regardless of success value

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a44c72516c832eb8c639abc8d30c21