### PR TITLE
Refine polling handling and prepare completion

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -250,7 +250,7 @@ export default function Page() {
           dispatch({
             type: "SET_STEP",
             step: "prepare",
-            patch: { polling: { isActive: true, logs: [ ...(state.steps.prepare.polling?.logs || []), payload ], last: payload } },
+            patch: { polling: { isActive: true, logs: [ ...(state.steps.prepare.polling?.logs || []), payload ] } },
           });
         },
         () => getEvents({ processId, DocumentId: documentId }, state.token),
@@ -258,7 +258,7 @@ export default function Page() {
           const events = p.events || p.Events;
           return (
             Array.isArray(events) &&
-            events.some((e: any) => e.Status === "preparation_success" && typeof e.Success === "boolean")
+            events.some((e: any) => e.Status === "preparation_success" && e.Success === true)
           );
         }
       );
@@ -286,7 +286,11 @@ export default function Page() {
         "send",
         processId,
         (payload) => {
-          dispatch({ type: "SET_STEP", step: "send", patch: { polling: { isActive: true, logs: [ ...(state.steps.send.polling?.logs || []), payload ], last: payload } } });
+          dispatch({
+            type: "SET_STEP",
+            step: "send",
+            patch: { polling: { isActive: true, logs: [ ...(state.steps.send.polling?.logs || []), payload ] } },
+          });
         },
         () => getEvents({ processId, DocumentId: state.documentId }, state.token),
         (p) => p.status === "completed"

--- a/src/components/PollingPanel.tsx
+++ b/src/components/PollingPanel.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Button, LinearProgress, Paper, Stack, Typography } from "@mui/material";
+import { Button, Stack } from "@mui/material";
 import JsonBox from "./JsonBox";
 import { StepState } from "../types";
 
@@ -11,27 +11,19 @@ interface Props {
 export default function PollingPanel({ polling, onStop }: Props) {
   if (!polling) return null;
   return (
-    <Paper variant="outlined" sx={{ p: 2 }}>
-      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 1 }}>
-        <Typography variant="subtitle2">Polling</Typography>
-        <Box sx={{ flexGrow: 1 }} />
-        {polling.isActive && onStop && (
-          <Button size="small" variant="text" color="error" onClick={onStop}>
-            Stop
-          </Button>
-        )}
-      </Stack>
-      <JsonBox label="Logs" data={polling.logs} />
-      {polling.last && (
-        <Box sx={{ mt: 1 }}>
-          <Typography variant="body2">Last Poll:</Typography>
-          <LinearProgress
-            variant="determinate"
-            value={polling.last.progress || 0}
-            sx={{ mt: 1 }}
-          />
-        </Box>
+    <Stack spacing={1}>
+      {polling.isActive && onStop && (
+        <Button
+          size="small"
+          variant="text"
+          color="error"
+          onClick={onStop}
+          sx={{ alignSelf: "flex-end" }}
+        >
+          Stop
+        </Button>
       )}
-    </Paper>
+      <JsonBox label="Polling Events" data={polling.logs} />
+    </Stack>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,6 @@ export interface StepState {
   polling?: {
     isActive: boolean;
     logs: any[];
-    last?: any;
   };
 }
 


### PR DESCRIPTION
## Summary
- Display polling events in a plain JSON box labeled "Polling Events" and drop last poll progress tracking
- Mark prepare step complete only after a `preparation_success` event reports Success=true

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a45356f5e0832e965383432baecff9