### PR TITLE
Hide navbar settings behind shortcut

### DIFF
--- a/src/components/Sidenav.tsx
+++ b/src/components/Sidenav.tsx
@@ -15,6 +15,7 @@ import {
   ListItemText,
   FormControlLabel,
   Switch,
+  Box,
 } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
@@ -39,6 +40,19 @@ interface SidenavProps {
 }
 
 export default function Sidenav({ state, dispatch, stepsOrder, runAll, go, settings, setSettings }: SidenavProps) {
+  const [showSettings, setShowSettings] = React.useState(false);
+
+  React.useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === "z") {
+        e.preventDefault();
+        setShowSettings((prev) => !prev);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
   const handleToggle = (key: keyof Settings) => (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.checked;
     const next = { ...settings, [key]: value };
@@ -50,32 +64,7 @@ export default function Sidenav({ state, dispatch, stepsOrder, runAll, go, setti
 
   return (
     <Paper elevation={0} sx={{ p: 2, height: "100%", overflow: "auto", borderRadius: 0 }}>
-      <Stack spacing={2}>
-        <Stack spacing={1}>
-          <Typography variant="subtitle1">Settings</Typography>
-          <FormControlLabel
-            control={<Switch checked={settings.enableAutomation} onChange={handleToggle("enableAutomation")} />}
-            label="Enable Automation"
-          />
-          <FormControlLabel
-            control={<Switch checked={settings.useLocalStorage} onChange={handleToggle("useLocalStorage")} />}
-            label="Use local storage"
-          />
-          {settings.enableAutomation && (
-            <TextField
-              label="Automation Delay (ms)"
-              type="number"
-              size="small"
-              value={state.autoDelayMs}
-              onChange={(e) =>
-                dispatch({ type: "SET_FIELD", key: "autoDelayMs", value: Number(e.target.value) })
-              }
-              fullWidth
-              sx={{ maxWidth: 400 }}
-            />
-          )}
-        </Stack>
-        <Divider />
+      <Stack spacing={2} sx={{ height: "100%" }}>
         <Stack direction="row" alignItems="center" justifyContent="space-between">
           <Typography variant="subtitle1">Steps</Typography>
           {settings.enableAutomation && (
@@ -100,30 +89,60 @@ export default function Sidenav({ state, dispatch, stepsOrder, runAll, go, setti
             const ActiveIcon =
               s === "success"
                 ? CheckCircleIcon
-              : s === "error"
-              ? ErrorIcon
-              : s === "running"
-              ? PendingIcon
-              : RadioButtonUncheckedIcon;
-          const color =
-            s === "success"
-              ? "success.main"
-              : s === "error"
-              ? "error.main"
-              : s === "running"
-              ? "info.main"
-              : "text.disabled";
-          return (
-            <ListItem key={key} disablePadding>
-              <ListItemButton selected={state.current === key} onClick={() => go(key)} sx={{ borderRadius: 1 }}>
-                <ListItemIcon>{icon}</ListItemIcon>
-                <ListItemText primary={label} />
-                <ActiveIcon fontSize="small" sx={{ color }} />
-              </ListItemButton>
-            </ListItem>
-          );
-        })}
+                : s === "error"
+                ? ErrorIcon
+                : s === "running"
+                ? PendingIcon
+                : RadioButtonUncheckedIcon;
+            const color =
+              s === "success"
+                ? "success.main"
+                : s === "error"
+                ? "error.main"
+                : s === "running"
+                ? "info.main"
+                : "text.disabled";
+            return (
+              <ListItem key={key} disablePadding>
+                <ListItemButton selected={state.current === key} onClick={() => go(key)} sx={{ borderRadius: 1 }}>
+                  <ListItemIcon>{icon}</ListItemIcon>
+                  <ListItemText primary={label} />
+                  <ActiveIcon fontSize="small" sx={{ color }} />
+                </ListItemButton>
+              </ListItem>
+            );
+          })}
         </List>
+        <Box sx={{ flexGrow: 1 }} />
+        {showSettings && (
+          <>
+            <Divider />
+            <Stack spacing={1}>
+              <Typography variant="subtitle1">Settings</Typography>
+              <FormControlLabel
+                control={<Switch checked={settings.enableAutomation} onChange={handleToggle("enableAutomation")} />}
+                label="Enable Automation"
+              />
+              <FormControlLabel
+                control={<Switch checked={settings.useLocalStorage} onChange={handleToggle("useLocalStorage")} />}
+                label="Use local storage"
+              />
+              {settings.enableAutomation && (
+                <TextField
+                  label="Automation Delay (ms)"
+                  type="number"
+                  size="small"
+                  value={state.autoDelayMs}
+                  onChange={(e) =>
+                    dispatch({ type: "SET_FIELD", key: "autoDelayMs", value: Number(e.target.value) })
+                  }
+                  fullWidth
+                  sx={{ maxWidth: 400 }}
+                />
+              )}
+            </Stack>
+          </>
+        )}
       </Stack>
     </Paper>
   );


### PR DESCRIPTION
## Summary
- Hide automation and storage settings by default
- Reveal settings with Ctrl+Shift+Z and place them at the bottom of the sidenav

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5b1d5ae68832e9d24764e0d7019e3