### PR TITLE
Improve form layout and loading indicators

### DIFF
--- a/src/components/JsonBox.tsx
+++ b/src/components/JsonBox.tsx
@@ -51,16 +51,16 @@ export default function JsonBox({ label, data }: { label: string; data: any }) {
         </IconButton>
       </Stack>
     </Stack>
-    <SyntaxHighlighter
-      language="json"
-      style={coldarkDark}
-      wrapLines={wrap}
-      wrapLongLines={wrap}
-      lineProps={{ style: { whiteSpace: wrap ? "pre-wrap" : "pre", wordBreak: wrap ? "break-word" : "normal" } }}
-      customStyle={{ margin: 0, fontSize: 16, borderRadius: 16 }}
-    >
-      {json || "—"}
-    </SyntaxHighlighter>
+      <SyntaxHighlighter
+        language="json"
+        style={coldarkDark}
+        wrapLines={wrap}
+        wrapLongLines={wrap}
+        lineProps={{ style: { whiteSpace: wrap ? "pre-wrap" : "pre", wordBreak: wrap ? "break-word" : "normal" } }}
+        customStyle={{ margin: 0, fontSize: 16, borderRadius: 16, maxHeight: 400, overflow: "auto" }}
+      >
+        {json || "—"}
+      </SyntaxHighlighter>
   </Paper>
 );
 }

--- a/src/components/Sidenav.tsx
+++ b/src/components/Sidenav.tsx
@@ -16,10 +16,10 @@ import {
   FormControlLabel,
   Switch,
   Box,
+  CircularProgress,
 } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
-import PendingIcon from "@mui/icons-material/Pending";
 import ErrorIcon from "@mui/icons-material/Error";
 import PlayCircleIcon from "@mui/icons-material/PlayCircle";
 import { WizardState, Action, StepKey } from "../types";
@@ -86,14 +86,6 @@ export default function Sidenav({ state, dispatch, stepsOrder, runAll, go, setti
         <List>
           {stepsOrder.map(({ key, label, icon }) => {
             const s = state.steps[key].status;
-            const ActiveIcon =
-              s === "success"
-                ? CheckCircleIcon
-                : s === "error"
-                ? ErrorIcon
-                : s === "running"
-                ? PendingIcon
-                : RadioButtonUncheckedIcon;
             const color =
               s === "success"
                 ? "success.main"
@@ -102,12 +94,22 @@ export default function Sidenav({ state, dispatch, stepsOrder, runAll, go, setti
                 : s === "running"
                 ? "info.main"
                 : "text.disabled";
+            const activeIcon =
+              s === "success" ? (
+                <CheckCircleIcon fontSize="small" sx={{ color }} />
+              ) : s === "error" ? (
+                <ErrorIcon fontSize="small" sx={{ color }} />
+              ) : s === "running" ? (
+                <CircularProgress size={16} sx={{ color }} />
+              ) : (
+                <RadioButtonUncheckedIcon fontSize="small" sx={{ color }} />
+              );
             return (
               <ListItem key={key} disablePadding>
                 <ListItemButton selected={state.current === key} onClick={() => go(key)} sx={{ borderRadius: 1 }}>
                   <ListItemIcon>{icon}</ListItemIcon>
                   <ListItemText primary={label} />
-                  <ActiveIcon fontSize="small" sx={{ color }} />
+                  {activeIcon}
                 </ListItemButton>
               </ListItem>
             );

--- a/src/components/steps/StepIntro.tsx
+++ b/src/components/steps/StepIntro.tsx
@@ -17,9 +17,10 @@ export default function StepIntro({ state, dispatch, onGetStarted }: Props) {
         Choose an environment and click <strong>Get Started</strong> to proceed. Client credentials will be entered in
         the next step. All data is kept in memory only; reloading the page will reset the wizard.
       </Typography>
-      <FormControl fullWidth sx={{ maxWidth: 400 }}>
+        <FormControl fullWidth size="small" sx={{ maxWidth: 400 }}>
         <InputLabel id="env-label">Environment</InputLabel>
         <Select
+          size="small"
           labelId="env-label"
           label="Environment"
           value={state.environment}

--- a/src/components/steps/StepPrepare.tsx
+++ b/src/components/steps/StepPrepare.tsx
@@ -5,6 +5,7 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  Grid,
   Stack,
   TextField,
   Typography,
@@ -30,45 +31,57 @@ export default function StepPrepare({ state, dispatch, runPrepareOrPrepareSend, 
         Choose an action and provide a list of recipient emails (comma-separated). If you choose <em>Prepare and Send</em>,
         Step 6 will be skipped.
       </Typography>
-      <FormControl fullWidth sx={{ maxWidth: 400 }}>
-        <InputLabel id="action-label">Action</InputLabel>
-        <Select
-          labelId="action-label"
-          label="Action"
-          value={state.actionChoice}
-          onChange={(e) => dispatch({ type: "SET_FIELD", key: "actionChoice", value: e.target.value })}
-        >
-          <MenuItem value="prepare">Prepare Contract</MenuItem>
-          <MenuItem value="prepare_send">Prepare and Send Contract</MenuItem>
-        </Select>
-      </FormControl>
-      <TextField
-        label="Title"
-        value={state.title}
-        onChange={(e) => dispatch({ type: "SET_FIELD", key: "title", value: e.target.value })}
-        fullWidth
-        sx={{ maxWidth: 400 }}
-      />
-      <FormControl fullWidth sx={{ maxWidth: 400 }}>
-        <InputLabel id="signature-class-label">Signature Class</InputLabel>
-        <Select
-          labelId="signature-class-label"
-          label="Signature Class"
-          value={state.signatureClass}
-          onChange={(e) => dispatch({ type: "SET_FIELD", key: "signatureClass", value: Number(e.target.value) })}
-        >
-          <MenuItem value={0}>Simple</MenuItem>
-          <MenuItem value={9}>Advanced</MenuItem>
-        </Select>
-      </FormControl>
-      <TextField
-        label="Emails (comma-separated)"
-        placeholder="a@x.com, b@y.com"
-        value={state.emails}
-        onChange={(e) => dispatch({ type: "SET_FIELD", key: "emails", value: e.target.value })}
-        fullWidth
-        sx={{ maxWidth: 400 }}
-      />
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={6}>
+          <FormControl fullWidth size="small" sx={{ maxWidth: 400 }}>
+            <InputLabel id="action-label">Action</InputLabel>
+            <Select
+              size="small"
+              labelId="action-label"
+              label="Action"
+              value={state.actionChoice}
+              onChange={(e) => dispatch({ type: "SET_FIELD", key: "actionChoice", value: e.target.value })}
+            >
+              <MenuItem value="prepare">Prepare Contract</MenuItem>
+              <MenuItem value="prepare_send">Prepare and Send Contract</MenuItem>
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Title"
+            value={state.title}
+            onChange={(e) => dispatch({ type: "SET_FIELD", key: "title", value: e.target.value })}
+            fullWidth
+            sx={{ maxWidth: 400 }}
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <FormControl fullWidth size="small" sx={{ maxWidth: 400 }}>
+            <InputLabel id="signature-class-label">Signature Class</InputLabel>
+            <Select
+              size="small"
+              labelId="signature-class-label"
+              label="Signature Class"
+              value={state.signatureClass}
+              onChange={(e) => dispatch({ type: "SET_FIELD", key: "signatureClass", value: Number(e.target.value) })}
+            >
+              <MenuItem value={0}>Simple</MenuItem>
+              <MenuItem value={9}>Advanced</MenuItem>
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Emails (comma-separated)"
+            placeholder="a@x.com, b@y.com"
+            value={state.emails}
+            onChange={(e) => dispatch({ type: "SET_FIELD", key: "emails", value: e.target.value })}
+            fullWidth
+            sx={{ maxWidth: 400 }}
+          />
+        </Grid>
+      </Grid>
       <Stack direction="row" spacing={2}>
         <Button
           variant="contained"


### PR DESCRIPTION
## Summary
- Replace pending dots in sidenav with a spinner
- Show Prepare step inputs in two columns on larger screens
- Align Select heights with TextField inputs and cap JsonBox height

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5b879bfcc832e8c39fcd3a4eef662