### PR TITLE
fix: avoid hydration mismatch for prepare step email input

### DIFF
--- a/src/components/steps/StepPrepare.tsx
+++ b/src/components/steps/StepPrepare.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from "react";
 import {
   Button,
@@ -71,14 +72,15 @@ export default function StepPrepare({ state, dispatch, runPrepareOrPrepareSend, 
             </Select>
           </FormControl>
         </Grid>
-        <Grid item xs={12} md={6}>
+        <Grid item xs={12}>
           <TextField
             label="Emails (comma-separated)"
             placeholder="a@x.com, b@y.com"
             value={state.emails}
-            onChange={(e) => dispatch({ type: "SET_FIELD", key: "emails", value: e.target.value })}
+            onChange={(e) =>
+              dispatch({ type: "SET_FIELD", key: "emails", value: e.target.value })
+            }
             fullWidth
-            sx={{ maxWidth: 400 }}
           />
         </Grid>
       </Grid>


### PR DESCRIPTION
## Summary
- mark prepare step as a client component to prevent hydration issues
- expand email field to span full width so addresses stay on one line

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5bb23cefc832eb878beeee16717a4