### PR TITLE
Flatten polling events and show polling spinner

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -263,7 +263,15 @@ export default function Page() {
           dispatch({
             type: "SET_STEP",
             step: "prepare",
-            patch: { polling: { isActive: true, logs: [ ...(state.steps.prepare.polling?.logs || []), payload ] } },
+            patch: {
+              polling: {
+                isActive: true,
+                logs: [
+                  ...(state.steps.prepare.polling?.logs || []),
+                  ...(Array.isArray(payload) ? payload : [payload]),
+                ],
+              },
+            },
           });
         },
         () => getEvents({ processId, DocumentId: documentId }, state.token),
@@ -301,7 +309,15 @@ export default function Page() {
           dispatch({
             type: "SET_STEP",
             step: "send",
-            patch: { polling: { isActive: true, logs: [ ...(state.steps.send.polling?.logs || []), payload ] } },
+            patch: {
+              polling: {
+                isActive: true,
+                logs: [
+                  ...(state.steps.send.polling?.logs || []),
+                  ...(Array.isArray(payload) ? payload : [payload]),
+                ],
+              },
+            },
           });
         },
         () => getEvents({ processId, DocumentId: state.documentId }, state.token),

--- a/src/components/PollingPanel.tsx
+++ b/src/components/PollingPanel.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Stack } from "@mui/material";
+import { Button, Stack, CircularProgress } from "@mui/material";
 import JsonBox from "./JsonBox";
 import { StepState } from "../types";
 
@@ -13,15 +13,22 @@ export default function PollingPanel({ polling, onStop }: Props) {
   return (
     <Stack spacing={1}>
       {polling.isActive && onStop && (
-        <Button
-          size="small"
-          variant="text"
-          color="error"
-          onClick={onStop}
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
           sx={{ alignSelf: "flex-end" }}
         >
-          Stop
-        </Button>
+          <CircularProgress size={16} />
+          <Button
+            size="small"
+            variant="text"
+            color="error"
+            onClick={onStop}
+          >
+            Stop
+          </Button>
+        </Stack>
       )}
       <JsonBox label="Polling Events" data={polling.logs} />
     </Stack>


### PR DESCRIPTION
## Summary
- flatten polling event logs to remove nested arrays
- display a spinner next to the stop button while polling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab24024a40832e85e11a0e4154167d