### PR TITLE
Hide polling spinner after completion and auto-scroll JSON

### DIFF
--- a/src/components/JsonBox.tsx
+++ b/src/components/JsonBox.tsx
@@ -15,6 +15,15 @@ const SyntaxHighlighter = dynamic(
 export default function JsonBox({ label, data }: { label: string; data: any }) {
   const [wrap, setWrap] = React.useState(false);
   const json = data ? JSON.stringify(data, null, 2) : "";
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const prevJson = React.useRef("");
+
+  React.useEffect(() => {
+    if (json && json !== prevJson.current && containerRef.current) {
+      containerRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+    prevJson.current = json;
+  }, [json]);
 
   const handleCopy = () => {
     if (!json) return;
@@ -37,7 +46,12 @@ export default function JsonBox({ label, data }: { label: string; data: any }) {
   };
 
   return (
-    <Paper variant="elevation" elevation={0} style={{ backgroundColor: "transparent" }}>
+    <Paper
+      ref={containerRef}
+      variant="elevation"
+      elevation={0}
+      style={{ backgroundColor: "transparent" }}
+    >
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ py: 1 }}>
         <Typography variant="subtitle2" gutterBottom>
           {label}

--- a/src/components/PollingPanel.tsx
+++ b/src/components/PollingPanel.tsx
@@ -5,14 +5,16 @@ import { StepState } from "../types";
 
 interface Props {
   polling?: StepState["polling"];
+  status?: StepState["status"];
   onStop?: () => void;
 }
 
-export default function PollingPanel({ polling, onStop }: Props) {
+export default function PollingPanel({ polling, status, onStop }: Props) {
   if (!polling) return null;
+  const showSpinner = polling.isActive && onStop && status === "running";
   return (
     <Stack spacing={1}>
-      {polling.isActive && onStop && (
+      {showSpinner && (
         <Stack
           direction="row"
           spacing={1}

--- a/src/components/steps/StepPrepare.tsx
+++ b/src/components/steps/StepPrepare.tsx
@@ -96,7 +96,11 @@ export default function StepPrepare({ state, dispatch, runPrepareOrPrepareSend, 
       <JsonBox label="Request" data={state.steps.prepare.request} />
       <JsonBox label="Response" data={state.steps.prepare.response} />
       {state.steps.prepare.error && <JsonBox label="Error" data={state.steps.prepare.error} />}
-      <PollingPanel polling={state.steps.prepare.polling} onStop={onStopPolling} />
+      <PollingPanel
+        polling={state.steps.prepare.polling}
+        status={state.steps.prepare.status}
+        onStop={onStopPolling}
+      />
       <Stack direction="row" spacing={2}>
         {state.actionChoice === "prepare" ? (
           <Button variant="outlined" onClick={() => go("send")}>Next</Button>

--- a/src/components/steps/StepSend.tsx
+++ b/src/components/steps/StepSend.tsx
@@ -31,7 +31,11 @@ export default function StepSend({ state, runSendOnly, go, onStopPolling }: Prop
       <JsonBox label="Request" data={state.steps.send.request} />
       <JsonBox label="Response" data={state.steps.send.response} />
       {state.steps.send.error && <JsonBox label="Error" data={state.steps.send.error} />}
-      <PollingPanel polling={state.steps.send.polling} onStop={onStopPolling} />
+      <PollingPanel
+        polling={state.steps.send.polling}
+        status={state.steps.send.status}
+        onStop={onStopPolling}
+      />
       <Stack direction="row" spacing={2}>
         <Button variant="outlined" onClick={() => go("done")}>Next</Button>
       </Stack>


### PR DESCRIPTION
## Summary
- stop showing polling spinner once a step finishes by checking step status
- scroll to JSON boxes when new responses or polling events appear

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab2926165c832ea9bdb2f13f997ead