### PR TITLE
Show polling controls during active requests

### DIFF
--- a/src/components/PollingPanel.tsx
+++ b/src/components/PollingPanel.tsx
@@ -5,13 +5,12 @@ import { StepState } from "../types";
 
 interface Props {
   polling?: StepState["polling"];
-  status?: StepState["status"];
   onStop?: () => void;
 }
 
-export default function PollingPanel({ polling, status, onStop }: Props) {
+export default function PollingPanel({ polling, onStop }: Props) {
   if (!polling) return null;
-  const showSpinner = polling.isActive && onStop && status === "running";
+  const showSpinner = polling.isActive && !!onStop;
   return (
     <Stack spacing={1}>
       {showSpinner && (

--- a/src/components/steps/StepPrepare.tsx
+++ b/src/components/steps/StepPrepare.tsx
@@ -98,7 +98,6 @@ export default function StepPrepare({ state, dispatch, runPrepareOrPrepareSend, 
       {state.steps.prepare.error && <JsonBox label="Error" data={state.steps.prepare.error} />}
       <PollingPanel
         polling={state.steps.prepare.polling}
-        status={state.steps.prepare.status}
         onStop={onStopPolling}
       />
       <Stack direction="row" spacing={2}>

--- a/src/components/steps/StepSend.tsx
+++ b/src/components/steps/StepSend.tsx
@@ -33,7 +33,6 @@ export default function StepSend({ state, runSendOnly, go, onStopPolling }: Prop
       {state.steps.send.error && <JsonBox label="Error" data={state.steps.send.error} />}
       <PollingPanel
         polling={state.steps.send.polling}
-        status={state.steps.send.status}
         onStop={onStopPolling}
       />
       <Stack direction="row" spacing={2}>


### PR DESCRIPTION
## Summary
- Display polling spinner and stop button whenever polling is active
- Remove unused status prop from polling panel calls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab305d35bc832eac9f2fd98745a8f9