### PR TITLE
Handle document-based polling and preparation failure events

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,7 @@ const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
     rules: {
-      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-explicit-any": "error",
     },
   },
 ];

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -163,6 +163,10 @@ function useDelay() {
 // —— Page ——
 export default function Page() {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
   const [settings, setSettings] = useState({ enableAutomation: false, useLocalStorage: false });
 
   useEffect(() => {
@@ -299,7 +303,7 @@ export default function Page() {
               polling: {
                 isActive: true,
                 logs: [
-                  ...(state.steps.prepare.polling?.logs || []),
+                  ...(stateRef.current.steps.prepare.polling?.logs || []),
                   ...(Array.isArray(payload) ? payload : [payload]),
                 ],
               },
@@ -322,7 +326,12 @@ export default function Page() {
       dispatch({
         type: "SET_STEP",
         step: "prepare",
-        patch: { polling: { isActive: false, logs: state.steps.prepare.polling?.logs || [] } },
+        patch: {
+          polling: {
+            isActive: false,
+            logs: stateRef.current.steps.prepare.polling?.logs || [],
+          },
+        },
       });
 
       const failed = Array.isArray(finalEvents)
@@ -341,7 +350,7 @@ export default function Page() {
     } catch (e: unknown) {
       dispatch({ type: "SET_STEP", step: "prepare", patch: { status: "error", error: String(e) } });
     }
-  }, [state.actionChoice, state.emails, state.fileId, state.title, state.signatureClass, state.token, state.steps.prepare.polling, poller]);
+  }, [state.actionChoice, state.emails, state.fileId, state.title, state.signatureClass, state.token, poller]);
 
   const runSendOnly = useCallback(async () => {
     try {
@@ -364,7 +373,7 @@ export default function Page() {
               polling: {
                 isActive: true,
                 logs: [
-                  ...(state.steps.send.polling?.logs || []),
+                  ...(stateRef.current.steps.send.polling?.logs || []),
                   ...(Array.isArray(payload) ? payload : [payload]),
                 ],
               },
@@ -377,14 +386,19 @@ export default function Page() {
       dispatch({
         type: "SET_STEP",
         step: "send",
-        patch: { polling: { isActive: false, logs: state.steps.send.polling?.logs || [] } },
+        patch: {
+          polling: {
+            isActive: false,
+            logs: stateRef.current.steps.send.polling?.logs || [],
+          },
+        },
       });
 
       setSnack("Contract sent via email.");
     } catch (e: unknown) {
       dispatch({ type: "SET_STEP", step: "send", patch: { status: "error", error: String(e) } });
     }
-  }, [state.documentId, state.token, state.steps.send.polling, poller]);
+  }, [state.documentId, state.token, poller]);
 
   // —— Automation ——
   const runAll = useCallback(async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -329,7 +329,10 @@ export default function Page() {
         patch: {
           polling: {
             isActive: false,
-            logs: stateRef.current.steps.prepare.polling?.logs || [],
+            logs: [
+              ...(stateRef.current.steps.prepare.polling?.logs || []),
+              ...(Array.isArray(finalEvents) ? finalEvents : [finalEvents]),
+            ],
           },
         },
       });
@@ -363,7 +366,7 @@ export default function Page() {
 
       // Polling for send
       dispatch({ type: "SET_STEP", step: "send", patch: { polling: { isActive: true, logs: [] } } });
-      await poller.start<{ status: string }>(
+      const finalEvent = await poller.start<{ status: string }>(
         "send",
         (payload) => {
           dispatch({
@@ -389,7 +392,10 @@ export default function Page() {
         patch: {
           polling: {
             isActive: false,
-            logs: stateRef.current.steps.send.polling?.logs || [],
+            logs: [
+              ...(stateRef.current.steps.send.polling?.logs || []),
+              ...(Array.isArray(finalEvent) ? finalEvent : [finalEvent]),
+            ],
           },
         },
       });

--- a/src/components/JsonBox.tsx
+++ b/src/components/JsonBox.tsx
@@ -12,7 +12,7 @@ const SyntaxHighlighter = dynamic(
   { ssr: false }
 );
 
-export default function JsonBox({ label, data }: { label: string; data: any }) {
+export default function JsonBox({ label, data }: { label: string; data: unknown }) {
   const [wrap, setWrap] = React.useState(false);
   const json = data ? JSON.stringify(data, null, 2) : "";
   const containerRef = React.useRef<HTMLDivElement>(null);

--- a/src/components/steps/StepDone.tsx
+++ b/src/components/steps/StepDone.tsx
@@ -13,7 +13,7 @@ export default function StepDone({ state }: Props) {
       <Typography variant="h5">Step 7 — Complete</Typography>
       <Alert severity="success">{message}</Alert>
       <Typography variant="body2">
-        You can go back to any step on the left to review payloads and polling responses. Reloading the page will reset
+        You can revisit each step on the left to review payloads and polling responses. Reloading the page will reset
         everything.
       </Typography>
     </Stack>

--- a/src/components/steps/StepPrepare.tsx
+++ b/src/components/steps/StepPrepare.tsx
@@ -6,7 +6,6 @@ import {
   InputLabel,
   MenuItem,
   Select,
-  Grid,
   Stack,
   TextField,
   Typography,
@@ -32,58 +31,48 @@ export default function StepPrepare({ state, dispatch, runPrepareOrPrepareSend, 
         Choose an action and provide a list of recipient emails (comma-separated). If you choose <em>Prepare and Send</em>,
         Step 6 will be skipped.
       </Typography>
-      <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
-          <FormControl fullWidth size="small" sx={{ maxWidth: 400 }}>
-            <InputLabel id="action-label">Action</InputLabel>
-            <Select
-              size="small"
-              labelId="action-label"
-              label="Action"
-              value={state.actionChoice}
-              onChange={(e) => dispatch({ type: "SET_FIELD", key: "actionChoice", value: e.target.value })}
-            >
-              <MenuItem value="prepare">Prepare Contract</MenuItem>
-              <MenuItem value="prepare_send">Prepare and Send Contract</MenuItem>
-            </Select>
-          </FormControl>
-        </Grid>
-        <Grid item xs={12} md={6}>
-          <TextField
-            label="Title"
-            value={state.title}
-            onChange={(e) => dispatch({ type: "SET_FIELD", key: "title", value: e.target.value })}
-            fullWidth
-            sx={{ maxWidth: 400 }}
-          />
-        </Grid>
-        <Grid item xs={12} md={6}>
-          <FormControl fullWidth size="small" sx={{ maxWidth: 400 }}>
-            <InputLabel id="signature-class-label">Signature Class</InputLabel>
-            <Select
-              size="small"
-              labelId="signature-class-label"
-              label="Signature Class"
-              value={state.signatureClass}
-              onChange={(e) => dispatch({ type: "SET_FIELD", key: "signatureClass", value: Number(e.target.value) })}
-            >
-              <MenuItem value={0}>Simple</MenuItem>
-              <MenuItem value={9}>Advanced</MenuItem>
-            </Select>
-          </FormControl>
-        </Grid>
-        <Grid item xs={12}>
-          <TextField
-            label="Emails (comma-separated)"
-            placeholder="a@x.com, b@y.com"
-            value={state.emails}
-            onChange={(e) =>
-              dispatch({ type: "SET_FIELD", key: "emails", value: e.target.value })
-            }
-            fullWidth
-          />
-        </Grid>
-      </Grid>
+      <Stack direction={{ xs: "column", md: "row" }} spacing={2}>
+        <FormControl fullWidth size="small" sx={{ maxWidth: 400 }}>
+          <InputLabel id="action-label">Action</InputLabel>
+          <Select
+            size="small"
+            labelId="action-label"
+            label="Action"
+            value={state.actionChoice}
+            onChange={(e) => dispatch({ type: "SET_FIELD", key: "actionChoice", value: e.target.value })}
+          >
+            <MenuItem value="prepare">Prepare Contract</MenuItem>
+            <MenuItem value="prepare_send">Prepare and Send Contract</MenuItem>
+          </Select>
+        </FormControl>
+        <TextField
+          label="Title"
+          value={state.title}
+          onChange={(e) => dispatch({ type: "SET_FIELD", key: "title", value: e.target.value })}
+          fullWidth
+          sx={{ maxWidth: 400 }}
+        />
+      </Stack>
+      <FormControl fullWidth size="small" sx={{ maxWidth: 400 }}>
+        <InputLabel id="signature-class-label">Signature Class</InputLabel>
+        <Select
+          size="small"
+          labelId="signature-class-label"
+          label="Signature Class"
+          value={state.signatureClass}
+          onChange={(e) => dispatch({ type: "SET_FIELD", key: "signatureClass", value: Number(e.target.value) })}
+        >
+          <MenuItem value={0}>Simple</MenuItem>
+          <MenuItem value={9}>Advanced</MenuItem>
+        </Select>
+      </FormControl>
+      <TextField
+        label="Emails (comma-separated)"
+        placeholder="a@x.com, b@y.com"
+        value={state.emails}
+        onChange={(e) => dispatch({ type: "SET_FIELD", key: "emails", value: e.target.value })}
+        fullWidth
+      />
       <Stack direction="row" spacing={2}>
         <Button
           variant="contained"
@@ -95,7 +84,7 @@ export default function StepPrepare({ state, dispatch, runPrepareOrPrepareSend, 
       </Stack>
       <JsonBox label="Request" data={state.steps.prepare.request} />
       <JsonBox label="Response" data={state.steps.prepare.response} />
-      {state.steps.prepare.error && <JsonBox label="Error" data={state.steps.prepare.error} />}
+      {!!state.steps.prepare.error && <JsonBox label="Error" data={state.steps.prepare.error} />}
       <PollingPanel
         polling={state.steps.prepare.polling}
         onStop={onStopPolling}

--- a/src/components/steps/StepSend.tsx
+++ b/src/components/steps/StepSend.tsx
@@ -30,7 +30,7 @@ export default function StepSend({ state, runSendOnly, go, onStopPolling }: Prop
       </Stack>
       <JsonBox label="Request" data={state.steps.send.request} />
       <JsonBox label="Response" data={state.steps.send.response} />
-      {state.steps.send.error && <JsonBox label="Error" data={state.steps.send.error} />}
+      {!!state.steps.send.error && <JsonBox label="Error" data={state.steps.send.error} />}
       <PollingPanel
         polling={state.steps.send.polling}
         onStop={onStopPolling}

--- a/src/components/steps/StepToken.tsx
+++ b/src/components/steps/StepToken.tsx
@@ -55,7 +55,7 @@ export default function StepToken({ state, dispatch, runToken, go, useLocalStora
       </Stack>
       <JsonBox label="Request" data={state.steps.token.request} />
       <JsonBox label="Response" data={state.steps.token.response} />
-      {s.error && <JsonBox label="Error" data={s.error} />}
+      {!!s.error && <JsonBox label="Error" data={s.error} />}
       <Stack direction="row" spacing={2}>
         <Button variant="outlined" onClick={() => go("uploadUrl")}>Next</Button>
       </Stack>

--- a/src/components/steps/StepUpload.tsx
+++ b/src/components/steps/StepUpload.tsx
@@ -11,10 +11,8 @@ interface Props {
 
 export default function StepUpload({ state, runUpload, go }: Props) {
   const s = state.steps.upload;
-  const uploadUrl =
-    state.uploadUrl ||
-    (state.steps.uploadUrl.response as any)?.url ||
-    (state.steps.uploadUrl.response as any)?.uploadUrl;
+  const uploadRes = state.steps.uploadUrl.response as { url?: string; uploadUrl?: string } | undefined;
+  const uploadUrl = state.uploadUrl || uploadRes?.url || uploadRes?.uploadUrl;
   return (
     <Stack spacing={2}>
       <Typography variant="h6">Step 4 — Upload File</Typography>
@@ -37,7 +35,7 @@ export default function StepUpload({ state, runUpload, go }: Props) {
       </Stack>
       <JsonBox label="Request" data={state.steps.upload.request} />
       <JsonBox label="Response" data={state.steps.upload.response} />
-      {state.steps.upload.error && <JsonBox label="Error" data={state.steps.upload.error} />}
+      {!!state.steps.upload.error && <JsonBox label="Error" data={state.steps.upload.error} />}
       <Stack direction="row" spacing={2}>
         <Button variant="outlined" onClick={() => go("prepare")}>Next</Button>
       </Stack>

--- a/src/components/steps/StepUploadUrl.tsx
+++ b/src/components/steps/StepUploadUrl.tsx
@@ -57,7 +57,7 @@ export default function StepUploadUrl({ state, dispatch, runGetUploadUrl, go }: 
       </Stack>
       <JsonBox label="Request" data={state.steps.uploadUrl.request} />
       <JsonBox label="Response" data={state.steps.uploadUrl.response} />
-      {s.error && <JsonBox label="Error" data={s.error} />}
+      {!!s.error && <JsonBox label="Error" data={s.error} />}
       <Stack direction="row" spacing={2}>
         <Button variant="outlined" onClick={() => go("upload")}>Next</Button>
       </Stack>

--- a/src/services/contract.ts
+++ b/src/services/contract.ts
@@ -63,13 +63,17 @@ export async function prepareAndSendContract(body: PrepareBody, token?: string) 
   return res.data;
 }
 
-export function buildSendContractRequest(body: any) {
+export interface SendBody {
+  DocumentId: string;
+}
+
+export function buildSendContractRequest(body: SendBody) {
   const { baseUrl, sendContractApi } = getEnv();
   const url = `${baseUrl}/${sendContractApi}`;
   return { url, body };
 }
 
-export async function sendContract(body: any, token?: string) {
+export async function sendContract(body: SendBody, token?: string) {
   const { url, body: payload } = buildSendContractRequest(body);
   const res = await axios.post(url, payload, {
     headers: token ? { Authorization: `bearer ${token}` } : undefined,
@@ -78,18 +82,21 @@ export async function sendContract(body: any, token?: string) {
 }
 
 interface GetEventsBody {
-  processId: string;
-  DocumentId?: string;
+  DocumentId: string;
+  processId?: string;
 }
 
-export async function getEvents({ processId, DocumentId }: GetEventsBody, token?: string) {
+export async function getEvents<T = unknown>(
+  { processId, DocumentId }: GetEventsBody,
+  token?: string
+): Promise<T> {
   const { baseUrl, getEventsApi } = getEnv();
   const url = `${baseUrl}/${getEventsApi}`;
-  const payload: any = { processId };
-  if (DocumentId) {
-    payload.DocumentId = DocumentId;
+  const payload: GetEventsBody = { DocumentId };
+  if (processId) {
+    payload.processId = processId;
   }
-  const res = await axios.post(url, payload, {
+  const res = await axios.post<T>(url, payload, {
     headers: token ? { Authorization: `bearer ${token}` } : undefined,
   });
   return res.data;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,12 +9,12 @@ export type StepKey =
 
 export interface StepState {
   status: "idle" | "running" | "success" | "error";
-  request?: any;
-  response?: any;
-  error?: any;
+  request?: unknown;
+  response?: unknown;
+  error?: unknown;
   polling?: {
     isActive: boolean;
-    logs: any[];
+    logs: unknown[];
   };
 }
 
@@ -28,7 +28,6 @@ export interface WizardState {
   fileName?: string;
   uploadUrl?: string;
   fileId?: string;
-  processId?: string;
   documentId?: string;
   title: string;
   signatureClass: number;
@@ -40,6 +39,6 @@ export interface WizardState {
 }
 
 export type Action =
-  | { type: "SET_FIELD"; key: keyof WizardState; value: any }
+  | { type: "SET_FIELD"; key: keyof WizardState; value: WizardState[keyof WizardState] }
   | { type: "SET_STEP"; step: StepKey; patch: Partial<StepState> }
   | { type: "GOTO"; step: StepKey };


### PR DESCRIPTION
## Summary
- Remove `any` usage by introducing generics, `unknown` types, and ESLint enforcement
- Detect `preperation_failed` events using a document-based poller and stop accordingly
- Replace Grid layout with Stack components in the prepare step to fix build issues

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1c02a00dc832eb684ebb562352eb1