### PR TITLE
feat: add send contract polling

### DIFF
--- a/src/services/contract.ts
+++ b/src/services/contract.ts
@@ -63,8 +63,36 @@ export async function prepareAndSendContract(body: PrepareBody, token?: string) 
   return res.data;
 }
 
+interface BaseCoordinate {
+  FileId: string;
+  Width: number;
+  Height: number;
+  PageNumber: number;
+  X: number;
+  Y: number;
+}
+
+interface StampCoordinate extends BaseCoordinate {
+  SignatoryEmail: string;
+  SignatureImageFileId: string;
+}
+
+interface TextFieldCoordinate extends BaseCoordinate {
+  SignatoryEmail: string;
+  Value: string;
+}
+
+interface StampPostInfoCoordinate extends BaseCoordinate {
+  EntityName: string;
+  PropertyName: string;
+  SignatoryEmail: string;
+}
+
 export interface SendBody {
   DocumentId: string;
+  StampCoordinates?: StampCoordinate[];
+  TextFieldCoordinates?: TextFieldCoordinate[];
+  StampPostInfoCoordinates?: StampPostInfoCoordinate[];
 }
 
 export function buildSendContractRequest(body: SendBody) {


### PR DESCRIPTION
## Summary
- extend `RolloutContract` request body to allow coordinate data for stamps and text fields
- implement Send Contract step with polling until `rolled_out_success` or `rolled_out_failed`
- unify coordinate interfaces and simplify event polling logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b28309e9bc832e85e7a450c929ec50