### PR TITLE
Reset polling logs to latest response

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -303,10 +303,7 @@ export default function Page() {
             patch: {
               polling: {
                 isActive: true,
-                logs: [
-                  ...(stateRef.current.steps.prepare.polling?.logs || []),
-                  ...payload,
-                ],
+                logs: payload,
               },
             },
           });
@@ -325,10 +322,7 @@ export default function Page() {
         patch: {
           polling: {
             isActive: false,
-            logs: [
-              ...(stateRef.current.steps.prepare.polling?.logs || []),
-              ...finalEvents,
-            ],
+            logs: finalEvents,
           },
         },
       });
@@ -409,10 +403,7 @@ export default function Page() {
             patch: {
               polling: {
                 isActive: true,
-                logs: [
-                  ...(stateRef.current.steps.send.polling?.logs || []),
-                  ...payload,
-                ],
+                logs: payload,
               },
             },
           });
@@ -431,10 +422,7 @@ export default function Page() {
         patch: {
           polling: {
             isActive: false,
-            logs: [
-              ...(stateRef.current.steps.send.polling?.logs || []),
-              ...finalEvents,
-            ],
+            logs: finalEvents,
           },
         },
       });


### PR DESCRIPTION
## Summary
- avoid appending polling events; replace logs with latest API response

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b29af4a2dc832eb85f2ba0660f957d