### PR TITLE
Filter polling events by step and use upload ItemId in coordinates

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -238,7 +238,7 @@ export default function Page() {
       dispatch({ type: "SET_STEP", step: "uploadUrl", patch: { request: { url, body } } });
       const data = await getUploadUrl(itemId, state.fileName || "file.pdf", state.token);
       dispatch({ type: "SET_FIELD", key: "uploadUrl", value: data.UploadUrl });
-      dispatch({ type: "SET_FIELD", key: "fileId", value: data.FileId });
+      dispatch({ type: "SET_FIELD", key: "fileId", value: itemId });
       dispatch({ type: "SET_STEP", step: "uploadUrl", patch: { status: "success", response: data } });
       setSnack("Upload URL acquired.");
     } catch (e: unknown) {
@@ -357,7 +357,7 @@ export default function Page() {
       const body: SendBody = {
         DocumentId: state.documentId!,
         StampCoordinates: emails.map((email, idx) => ({
-          FileId: uuidv4(),
+          FileId: state.fileId!,
           Width: 150,
           Height: 100,
           PageNumber: 0,
@@ -366,7 +366,7 @@ export default function Page() {
           SignatoryEmail: email,
         })),
         TextFieldCoordinates: emails.map((email, idx) => ({
-          FileId: uuidv4(),
+          FileId: state.fileId!,
           Width: 127.7043269230769,
           Height: 27.043269230769226,
           PageNumber: 0,
@@ -376,7 +376,7 @@ export default function Page() {
           Value: "Hello World!",
         })),
         StampPostInfoCoordinates: emails.map((email, idx) => ({
-          FileId: uuidv4(),
+          FileId: state.fileId!,
           Width: 127.7043269230769,
           Height: 27.043269230769226,
           PageNumber: 0,
@@ -441,7 +441,7 @@ export default function Page() {
     } catch (e: unknown) {
       dispatch({ type: "SET_STEP", step: "send", patch: { status: "error", error: String(e) } });
     }
-  }, [state.documentId, state.token, state.emails, poller]);
+  }, [state.documentId, state.token, state.emails, state.fileId, poller]);
 
   // —— Automation ——
   const runAll = useCallback(async () => {

--- a/src/components/PollingPanel.tsx
+++ b/src/components/PollingPanel.tsx
@@ -1,16 +1,33 @@
 import React from "react";
 import { Button, Stack, CircularProgress } from "@mui/material";
 import JsonBox from "./JsonBox";
-import { StepState } from "../types";
+import { StepKey, StepState } from "../types";
 
 interface Props {
   polling?: StepState["polling"];
   onStop?: () => void;
+  step?: StepKey;
 }
 
-export default function PollingPanel({ polling, onStop }: Props) {
+function filterLogs(logs: unknown[], step?: StepKey) {
+  if (!step) return logs;
+  return logs.filter((e) => {
+    const obj = e as Record<string, unknown>;
+    const status = String(obj["Status"] ?? "").toLowerCase();
+    if (step === "prepare") {
+      return status.startsWith("preparation");
+    }
+    if (step === "send") {
+      return status.startsWith("rolled_out");
+    }
+    return true;
+  });
+}
+
+export default function PollingPanel({ polling, onStop, step }: Props) {
   if (!polling) return null;
   const showSpinner = polling.isActive && !!onStop;
+  const logs = filterLogs(polling.logs, step);
   return (
     <Stack spacing={1}>
       {showSpinner && (
@@ -31,7 +48,7 @@ export default function PollingPanel({ polling, onStop }: Props) {
           </Button>
         </Stack>
       )}
-      <JsonBox label="Polling Events" data={polling.logs} />
+      <JsonBox label="Polling Events" data={logs} />
     </Stack>
   );
 }

--- a/src/components/steps/StepPrepare.tsx
+++ b/src/components/steps/StepPrepare.tsx
@@ -86,6 +86,7 @@ export default function StepPrepare({ state, dispatch, runPrepareOrPrepareSend, 
       <JsonBox label="Response" data={state.steps.prepare.response} />
       {!!state.steps.prepare.error && <JsonBox label="Error" data={state.steps.prepare.error} />}
       <PollingPanel
+        step="prepare"
         polling={state.steps.prepare.polling}
         onStop={onStopPolling}
       />

--- a/src/components/steps/StepSend.tsx
+++ b/src/components/steps/StepSend.tsx
@@ -32,6 +32,7 @@ export default function StepSend({ state, runSendOnly, go, onStopPolling }: Prop
       <JsonBox label="Response" data={state.steps.send.response} />
       {!!state.steps.send.error && <JsonBox label="Error" data={state.steps.send.error} />}
       <PollingPanel
+        step="send"
         polling={state.steps.send.polling}
         onStop={onStopPolling}
       />


### PR DESCRIPTION
## Summary
- filter polling events by step using full Status values and remove redundant array checks
- track the ItemId used to obtain an upload URL and reuse it for coordinate FileId values

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3107254b4832eaa3388964af469c9