### PR TITLE
feat: add cachebuster to GET requests

### DIFF
--- a/src/services/contract.ts
+++ b/src/services/contract.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios from "./http";
 import { v4 as uuidv4 } from "uuid";
 import { getEnv } from "../env";
 

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -1,0 +1,16 @@
+import axios from "axios";
+
+axios.interceptors.request.use((config) => {
+  if (config.method?.toLowerCase() === "get") {
+    const cachebuster = Date.now();
+    if (config.params instanceof URLSearchParams) {
+      config.params.set("cachebuster", cachebuster.toString());
+    } else {
+      const params = config.params as Record<string, unknown> | undefined;
+      config.params = { ...(params ?? {}), cachebuster };
+    }
+  }
+  return config;
+});
+
+export default axios;

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios from "./http";
 import { getEnv } from "../env";
 
 function buildGetUploadUrlBody(itemId: string, name: string) {

--- a/src/services/token.ts
+++ b/src/services/token.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios from "./http";
 import { getEnv } from "../env";
 
 export function buildTokenRequest(clientId: string, clientSecret: string) {


### PR DESCRIPTION
## Summary
- add axios interceptor that appends timestamp-based cachebuster to GET requests
- use shared HTTP client in token, contract, and storage services

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5ba7fdf24832ea1e340272a2161e4