### PR TITLE
Fix rollout polling filter

### DIFF
--- a/src/components/PollingPanel.tsx
+++ b/src/components/PollingPanel.tsx
@@ -18,7 +18,7 @@ function filterLogs(logs: unknown[], step?: StepKey) {
       return status.startsWith("preparation");
     }
     if (step === "send") {
-      return status.startsWith("rolled_out");
+      return status.startsWith("rollout");
     }
     return true;
   });


### PR DESCRIPTION
## Summary
- show rollout polling events during Send Contract step

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b70222791c832e8b6f2aaa1144ae88